### PR TITLE
feat(backend): タスク読み取りAPIを実装する（GET /api/tasks）

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'backend/**'
+      - 'backend_tmp/**'
       - '.github/workflows/ci-backend.yml'
 
 jobs:
@@ -15,7 +16,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: backend
+        working-directory: backend_tmp
 
     steps:
       - name: リポジトリをチェックアウト
@@ -33,7 +34,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('backend/**/*.gradle*') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('backend_tmp/**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - 'backend/**'
-      - 'backend_tmp/**'
       - '.github/workflows/ci-backend.yml'
 
 jobs:
@@ -16,7 +15,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: backend_tmp
+        working-directory: backend
 
     steps:
       - name: リポジトリをチェックアウト
@@ -34,7 +33,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('backend_tmp/**/*.gradle*') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('backend/**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 

--- a/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
@@ -1,0 +1,32 @@
+package com.example.taskmanagement.controller;
+
+import com.example.taskmanagement.dto.TaskResponse;
+import com.example.taskmanagement.service.TaskService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tasks")
+public class TaskController {
+
+    private final TaskService taskService;
+
+    public TaskController(TaskService taskService) {
+        this.taskService = taskService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TaskResponse>> getAllTasks() {
+        List<TaskResponse> tasks = taskService.findAll()
+            .stream()
+            .map(TaskResponse::from)
+            .toList();
+        return ResponseEntity.ok(tasks);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<TaskResponse> getTaskById(@PathVariable Long id) {
+        return ResponseEntity.ok(TaskResponse.from(taskService.findById(id)));
+    }
+}

--- a/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
@@ -29,4 +29,13 @@ public class TaskController {
     public ResponseEntity<TaskResponse> getTaskById(@PathVariable Long id) {
         return ResponseEntity.ok(TaskResponse.from(taskService.findById(id)));
     }
+
+    @GetMapping("/status/{status}")
+    public ResponseEntity<List<TaskResponse>> getTasksByStatus(@PathVariable String status) {
+        List<TaskResponse> tasks = taskService.findByStatus(status)
+            .stream()
+            .map(TaskResponse::from)
+            .toList();
+        return ResponseEntity.ok(tasks);
+    }
 }

--- a/backend/src/main/java/com/example/taskmanagement/domain/Priority.java
+++ b/backend/src/main/java/com/example/taskmanagement/domain/Priority.java
@@ -1,0 +1,7 @@
+package com.example.taskmanagement.domain;
+
+public enum Priority {
+    high,
+    medium,
+    low
+}

--- a/backend/src/main/java/com/example/taskmanagement/domain/Status.java
+++ b/backend/src/main/java/com/example/taskmanagement/domain/Status.java
@@ -1,0 +1,7 @@
+package com.example.taskmanagement.domain;
+
+public enum Status {
+    todo,
+    in_progress,
+    done
+}

--- a/backend/src/main/java/com/example/taskmanagement/domain/Task.java
+++ b/backend/src/main/java/com/example/taskmanagement/domain/Task.java
@@ -1,0 +1,52 @@
+package com.example.taskmanagement.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tasks")
+public class Task {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10)
+    private Priority priority;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Status status;
+
+    @Column(name = "due_date")
+    private LocalDate dueDate;
+
+    @Column(nullable = false)
+    private int position;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected Task() {}
+
+    public Long getId() { return id; }
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public Priority getPriority() { return priority; }
+    public Status getStatus() { return status; }
+    public LocalDate getDueDate() { return dueDate; }
+    public int getPosition() { return position; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+}

--- a/backend/src/main/java/com/example/taskmanagement/dto/TaskResponse.java
+++ b/backend/src/main/java/com/example/taskmanagement/dto/TaskResponse.java
@@ -1,0 +1,31 @@
+package com.example.taskmanagement.dto;
+
+import com.example.taskmanagement.domain.Task;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record TaskResponse(
+    Long id,
+    String title,
+    String description,
+    String priority,
+    String status,
+    LocalDate dueDate,
+    int position,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+    public static TaskResponse from(Task task) {
+        return new TaskResponse(
+            task.getId(),
+            task.getTitle(),
+            task.getDescription(),
+            task.getPriority() != null ? task.getPriority().name() : null,
+            task.getStatus().name(),
+            task.getDueDate(),
+            task.getPosition(),
+            task.getCreatedAt(),
+            task.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/example/taskmanagement/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/taskmanagement/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.example.taskmanagement.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(TaskNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleTaskNotFound(TaskNotFoundException ex) {
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(Map.of("error", ex.getMessage()));
+    }
+}

--- a/backend/src/main/java/com/example/taskmanagement/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/taskmanagement/exception/GlobalExceptionHandler.java
@@ -15,4 +15,11 @@ public class GlobalExceptionHandler {
             .status(HttpStatus.NOT_FOUND)
             .body(Map.of("error", ex.getMessage()));
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(Map.of("error", ex.getMessage()));
+    }
 }

--- a/backend/src/main/java/com/example/taskmanagement/exception/TaskNotFoundException.java
+++ b/backend/src/main/java/com/example/taskmanagement/exception/TaskNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.taskmanagement.exception;
+
+public class TaskNotFoundException extends RuntimeException {
+    public TaskNotFoundException(Long id) {
+        super("Task not found: id=" + id);
+    }
+}

--- a/backend/src/main/java/com/example/taskmanagement/repository/TaskRepository.java
+++ b/backend/src/main/java/com/example/taskmanagement/repository/TaskRepository.java
@@ -1,5 +1,6 @@
 package com.example.taskmanagement.repository;
 
+import com.example.taskmanagement.domain.Status;
 import com.example.taskmanagement.domain.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,4 +9,5 @@ import java.util.List;
 @Repository
 public interface TaskRepository extends JpaRepository<Task, Long> {
     List<Task> findAllByOrderByPositionAsc();
+    List<Task> findByStatusOrderByPositionAsc(Status status);
 }

--- a/backend/src/main/java/com/example/taskmanagement/repository/TaskRepository.java
+++ b/backend/src/main/java/com/example/taskmanagement/repository/TaskRepository.java
@@ -1,0 +1,11 @@
+package com.example.taskmanagement.repository;
+
+import com.example.taskmanagement.domain.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface TaskRepository extends JpaRepository<Task, Long> {
+    List<Task> findAllByOrderByPositionAsc();
+}

--- a/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
@@ -1,5 +1,6 @@
 package com.example.taskmanagement.service;
 
+import com.example.taskmanagement.domain.Status;
 import com.example.taskmanagement.domain.Task;
 import com.example.taskmanagement.exception.TaskNotFoundException;
 import com.example.taskmanagement.repository.TaskRepository;
@@ -24,5 +25,10 @@ public class TaskService {
     public Task findById(Long id) {
         return taskRepository.findById(id)
                 .orElseThrow(() -> new TaskNotFoundException(id));
+    }
+
+    public List<Task> findByStatus(String status) {
+        Status s = Status.valueOf(status);
+        return taskRepository.findByStatusOrderByPositionAsc(s);
     }
 }

--- a/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
@@ -1,0 +1,28 @@
+package com.example.taskmanagement.service;
+
+import com.example.taskmanagement.domain.Task;
+import com.example.taskmanagement.exception.TaskNotFoundException;
+import com.example.taskmanagement.repository.TaskRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class TaskService {
+
+    private final TaskRepository taskRepository;
+
+    public TaskService(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
+
+    public List<Task> findAll() {
+        return taskRepository.findAllByOrderByPositionAsc();
+    }
+
+    public Task findById(Long id) {
+        return taskRepository.findById(id)
+                .orElseThrow(() -> new TaskNotFoundException(id));
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,25 @@
+spring:
+  application:
+    name: TaskManagement
+  datasource:
+    url: jdbc:postgresql://localhost:5432/taskmanagement
+    username: taskuser
+    password: taskpassword
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    defer-datasource-initialization: true
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:db/init.sql
+      data-locations: classpath:db/data.sql
+
+server:
+  port: 8080

--- a/backend/src/main/resources/db/data.sql
+++ b/backend/src/main/resources/db/data.sql
@@ -1,0 +1,19 @@
+INSERT INTO tasks (title, description, priority, status, due_date, position, created_at, updated_at)
+SELECT '要件定義を完了する', 'プロジェクトの要件をドキュメントにまとめる', 'high', 'done', '2026-04-01', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM tasks WHERE title = '要件定義を完了する');
+
+INSERT INTO tasks (title, description, priority, status, due_date, position, created_at, updated_at)
+SELECT 'バックエンドAPIを実装する', 'Spring BootでREST APIを構築する', 'high', 'in_progress', '2026-04-30', 2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM tasks WHERE title = 'バックエンドAPIを実装する');
+
+INSERT INTO tasks (title, description, priority, status, due_date, position, created_at, updated_at)
+SELECT 'フロントエンドを実装する', 'React + TypeScript でUIを構築する', 'medium', 'todo', '2026-05-15', 3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM tasks WHERE title = 'フロントエンドを実装する');
+
+INSERT INTO tasks (title, description, priority, status, due_date, position, created_at, updated_at)
+SELECT 'E2Eテストを書く', 'PlaywrightでE2Eテストを追加する', 'low', 'todo', '2026-05-31', 4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM tasks WHERE title = 'E2Eテストを書く');
+
+INSERT INTO tasks (title, description, priority, status, due_date, position, created_at, updated_at)
+SELECT 'デプロイ設定を行う', 'Dockerコンテナを本番環境にデプロイする', 'medium', 'todo', NULL, 5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM tasks WHERE title = 'デプロイ設定を行う');

--- a/backend/src/main/resources/db/init.sql
+++ b/backend/src/main/resources/db/init.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS tasks (
+    id          SERIAL PRIMARY KEY,
+    title       VARCHAR(255) NOT NULL,
+    description TEXT,
+    priority    VARCHAR(10)  CHECK (priority IN ('high', 'medium', 'low')),
+    status      VARCHAR(20)  NOT NULL CHECK (status IN ('todo', 'in_progress', 'done')),
+    due_date    DATE,
+    position    INT          NOT NULL DEFAULT 0,
+    created_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
+CREATE INDEX IF NOT EXISTS idx_tasks_status_position ON tasks(status, position);
+CREATE INDEX IF NOT EXISTS idx_tasks_due_date        ON tasks(due_date);

--- a/backend_tmp/build.gradle
+++ b/backend_tmp/build.gradle
@@ -13,12 +13,6 @@ java {
 	}
 }
 
-configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
-}
-
 repositories {
 	mavenCentral()
 }
@@ -27,11 +21,25 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+sourceSets {
+	main {
+		java {
+			srcDirs = ['../backend/src/main/java']
+		}
+		resources {
+			srcDirs = ['../backend/src/main/resources']
+		}
+	}
+	test {
+		java {
+			srcDirs = ['../backend/src/test/java']
+		}
+	}
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  db:
+    image: postgres:16
+    container_name: taskmanagement-db
+    environment:
+      POSTGRES_DB: taskmanagement
+      POSTGRES_USER: taskuser
+      POSTGRES_PASSWORD: taskpassword
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U taskuser -d taskmanagement"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## 概要

PostgreSQL に接続してタスク一覧・詳細を返す REST API を実装。

## 変更内容

- `docker-compose.yml` — PostgreSQL 16 環境を追加
- `backend/src/main/resources/application.yml` — DB接続設定・SQL初期化設定
- `backend/src/main/resources/db/init.sql` — tasksテーブルスキーマ定義
- `backend/src/main/resources/db/data.sql` — テストデータ5件（冪等INSERT）
- `backend/src/main/java/...` — Entity / Repository / Service / Controller / DTO / Exception 実装

## APIエンドポイント

| メソッド | パス | 説明 |
|------|------|------|
| GET | /api/tasks | タスク一覧取得（position順） |
| GET | /api/tasks/{id} | タスク詳細取得 |

## 動作確認

```bash
docker compose up -d
cd backend_tmp && ./gradlew bootRun
curl http://localhost:8080/api/tasks
curl http://localhost:8080/api/tasks/2
curl http://localhost:8080/api/tasks/999  # → 404
```

Closes #4