### PR TITLE
feat(backend): CorsConfig を追加してフロントエンドからのアクセスを許可

### DIFF
--- a/backend/src/main/java/com/example/taskmanagement/config/CorsConfig.java
+++ b/backend/src/main/java/com/example/taskmanagement/config/CorsConfig.java
@@ -1,0 +1,17 @@
+package com.example.taskmanagement.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*");
+    }
+}


### PR DESCRIPTION
## 概要

フロントエンド（localhost:5173）からバックエンドAPI（localhost:8080）への CORS リクエストを許可するための設定を追加。

## 変更内容

- `backend/src/main/java/com/example/taskmanagement/config/CorsConfig.java` を新規作成
  - 許可オリジン: `http://localhost:5173`（Vite 開発サーバー）
  - 許可メソッド: GET, POST, PATCH, DELETE, OPTIONS
  - 許可パス: `/api/**`

## テスト手順

1. バックエンドを起動: `cd backend && ./gradlew bootRun`
2. `curl -H "Origin: http://localhost:5173" http://localhost:8080/api/tasks` でレスポンスヘッダーに `Access-Control-Allow-Origin: http://localhost:5173` が含まれることを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)