### PR TITLE
fix(docs): start-servers スキルを CLAUDE.md のカスタムスキルセクションに登録する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,16 @@ docker compose up -d
 
 ---
 
+## カスタムスキル
+
+`/` コマンドで呼び出せるスキルを以下に登録する。スキルの詳細は各 SKILL.md を参照。
+
+| スキル名 | 説明 | SKILL.md |
+|----------|------|----------|
+| `start-servers` | バックエンド（:8080）とフロントエンド（:5173）の開発サーバーを起動する。ポート競合時は競合プロセスを停止してからデフォルトポートで起動する。 | [.claude/skills/start-servers/SKILL.md](.claude/skills/start-servers/SKILL.md) |
+
+---
+
 ## やってはいけないこと（禁止事項）
 
 - `git push origin main` — 直接プッシュ禁止


### PR DESCRIPTION
## 概要

- CLAUDE.md にカスタムスキルセクションを追加し、`start-servers` スキルを登録した
- これにより `/start-servers` が Claude Code から認識されるようになる

## 変更内容

- `CLAUDE.md` にカスタムスキルセクション（テーブル形式）を追加
- `start-servers` スキルの説明と SKILL.md へのリンクを記載

## 達成条件の検証結果

- [x] `/start-servers` が Claude Code で認識される — CLAUDE.md 登録により達成
- [x] ポート競合時に競合プロセスが停止されデフォルトポートで起動される — SKILL.md の手順通り `lsof -ti:<port> | xargs kill` で解放後に起動
- [x] バックエンド (port 8080) が正常起動する — `curl http://localhost:8080/api/tasks` で200レスポンス確認済み
- [x] フロントエンド (port 5173) が正常起動する — `curl http://localhost:5173` で200レスポンス確認済み

Closes #14