### PR TITLE
feat(backend/frontend): タスク新規登録機能を実装する

### DIFF
--- a/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
@@ -1,9 +1,14 @@
 package com.example.taskmanagement.controller;
 
+import com.example.taskmanagement.domain.Task;
+import com.example.taskmanagement.dto.TaskCreateRequest;
 import com.example.taskmanagement.dto.TaskResponse;
 import com.example.taskmanagement.service.TaskService;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -37,5 +42,14 @@ public class TaskController {
             .map(TaskResponse::from)
             .toList();
         return ResponseEntity.ok(tasks);
+    }
+
+    @PostMapping
+    public ResponseEntity<TaskResponse> createTask(
+            @RequestBody @Valid TaskCreateRequest req,
+            UriComponentsBuilder ucb) {
+        Task created = taskService.create(req);
+        URI location = ucb.path("/api/tasks/{id}").buildAndExpand(created.getId()).toUri();
+        return ResponseEntity.created(location).body(TaskResponse.from(created));
     }
 }

--- a/backend/src/main/java/com/example/taskmanagement/domain/Task.java
+++ b/backend/src/main/java/com/example/taskmanagement/domain/Task.java
@@ -40,6 +40,21 @@ public class Task {
 
     protected Task() {}
 
+    public static Task create(String title, String description, Priority priority,
+                              LocalDate dueDate, int position) {
+        Task t = new Task();
+        t.title = title;
+        t.description = description;
+        t.priority = priority;
+        t.status = Status.todo;
+        t.dueDate = dueDate;
+        t.position = position;
+        LocalDateTime now = LocalDateTime.now();
+        t.createdAt = now;
+        t.updatedAt = now;
+        return t;
+    }
+
     public Long getId() { return id; }
     public String getTitle() { return title; }
     public String getDescription() { return description; }

--- a/backend/src/main/java/com/example/taskmanagement/dto/TaskCreateRequest.java
+++ b/backend/src/main/java/com/example/taskmanagement/dto/TaskCreateRequest.java
@@ -1,0 +1,17 @@
+package com.example.taskmanagement.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public record TaskCreateRequest(
+    @NotBlank(message = "タイトルは必須です")
+    @Size(max = 255, message = "タイトルは255文字以内で入力してください")
+    String title,
+
+    String description,
+
+    String priority,
+
+    LocalDate dueDate
+) {}

--- a/backend/src/main/java/com/example/taskmanagement/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/taskmanagement/exception/GlobalExceptionHandler.java
@@ -2,9 +2,12 @@ package com.example.taskmanagement.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -21,5 +24,16 @@ public class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors()
+            .stream()
+            .map(FieldError::getDefaultMessage)
+            .collect(Collectors.joining(", "));
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(Map.of("error", message));
     }
 }

--- a/backend/src/main/java/com/example/taskmanagement/repository/TaskRepository.java
+++ b/backend/src/main/java/com/example/taskmanagement/repository/TaskRepository.java
@@ -5,9 +5,11 @@ import com.example.taskmanagement.domain.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TaskRepository extends JpaRepository<Task, Long> {
     List<Task> findAllByOrderByPositionAsc();
     List<Task> findByStatusOrderByPositionAsc(Status status);
+    Optional<Task> findTopByOrderByPositionDesc();
 }

--- a/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
@@ -1,7 +1,9 @@
 package com.example.taskmanagement.service;
 
+import com.example.taskmanagement.domain.Priority;
 import com.example.taskmanagement.domain.Status;
 import com.example.taskmanagement.domain.Task;
+import com.example.taskmanagement.dto.TaskCreateRequest;
 import com.example.taskmanagement.exception.TaskNotFoundException;
 import com.example.taskmanagement.repository.TaskRepository;
 import org.springframework.stereotype.Service;
@@ -30,5 +32,23 @@ public class TaskService {
     public List<Task> findByStatus(String status) {
         Status s = Status.valueOf(status);
         return taskRepository.findByStatusOrderByPositionAsc(s);
+    }
+
+    @Transactional
+    public Task create(TaskCreateRequest req) {
+        int nextPosition = taskRepository.findTopByOrderByPositionDesc()
+            .map(t -> t.getPosition() + 1)
+            .orElse(1);
+
+        Priority priority = null;
+        if (req.priority() != null && !req.priority().isBlank()) {
+            try {
+                priority = Priority.valueOf(req.priority());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("無効な優先度です: " + req.priority());
+            }
+        }
+
+        return taskRepository.save(Task.create(req.title(), req.description(), priority, req.dueDate(), nextPosition));
     }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import type { TaskResponse, TaskStatus } from './types/task'
 import { fetchAllTasks, fetchTasksByStatus } from './api/taskApi'
 import FilterBar from './components/FilterBar'
 import Board from './components/Board'
+import TaskForm from './components/TaskForm'
 
 type Filter = TaskStatus | 'all'
 
@@ -11,8 +12,9 @@ export default function App() {
   const [selectedStatus, setSelectedStatus] = useState<Filter>('all')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [showForm, setShowForm] = useState(false)
 
-  useEffect(() => {
+  const loadTasks = useCallback(() => {
     setLoading(true)
     setError(null)
 
@@ -27,6 +29,13 @@ export default function App() {
       .finally(() => setLoading(false))
   }, [selectedStatus])
 
+  useEffect(() => { loadTasks() }, [loadTasks])
+
+  const handleCreated = () => {
+    setShowForm(false)
+    loadTasks()
+  }
+
   return (
     <div className="min-h-screen bg-gray-100">
       <header className="bg-white border-b border-gray-200 px-6 py-4">
@@ -34,7 +43,22 @@ export default function App() {
       </header>
 
       <main className="p-6 space-y-4">
-        <FilterBar selected={selectedStatus} onChange={setSelectedStatus} />
+        <div className="flex items-center gap-4">
+          <FilterBar selected={selectedStatus} onChange={setSelectedStatus} />
+          <button
+            onClick={() => setShowForm((v) => !v)}
+            className="px-4 py-1.5 rounded-full text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+          >
+            {showForm ? '閉じる' : '+ 新規タスク'}
+          </button>
+        </div>
+
+        {showForm && (
+          <TaskForm
+            onClose={() => setShowForm(false)}
+            onCreated={handleCreated}
+          />
+        )}
 
         {loading && (
           <p className="text-sm text-gray-500">読み込み中...</p>

--- a/frontend/src/api/taskApi.ts
+++ b/frontend/src/api/taskApi.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { TaskResponse, TaskStatus } from '../types/task'
+import type { TaskResponse, TaskStatus, TaskCreateRequest } from '../types/task'
 
 const api = axios.create({ baseURL: '/api' })
 
@@ -10,5 +10,10 @@ export async function fetchAllTasks(): Promise<TaskResponse[]> {
 
 export async function fetchTasksByStatus(status: TaskStatus): Promise<TaskResponse[]> {
   const res = await api.get<TaskResponse[]>(`/tasks/status/${status}`)
+  return res.data
+}
+
+export async function createTask(req: TaskCreateRequest): Promise<TaskResponse> {
+  const res = await api.post<TaskResponse>('/tasks', req)
   return res.data
 }

--- a/frontend/src/components/TaskForm.tsx
+++ b/frontend/src/components/TaskForm.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react'
+import type { TaskPriority, TaskCreateRequest } from '../types/task'
+import { createTask } from '../api/taskApi'
+
+interface Props {
+  onClose: () => void
+  onCreated: () => void
+}
+
+export default function TaskForm({ onClose, onCreated }: Props) {
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [priority, setPriority] = useState<TaskPriority | ''>('')
+  const [dueDate, setDueDate] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!title.trim()) {
+      setError('タイトルは必須です')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    const req: TaskCreateRequest = {
+      title: title.trim(),
+      description: description.trim() || null,
+      priority: priority || null,
+      dueDate: dueDate || null,
+    }
+    try {
+      await createTask(req)
+      onCreated()
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { error?: string } } })?.response?.data?.error
+        ?? 'タスクの作成に失敗しました'
+      setError(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 w-full max-w-md">
+      <h2 className="text-sm font-bold text-gray-800 mb-4">新規タスク</h2>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            タイトル <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={255}
+            className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">説明</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-400 resize-none"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">優先度</label>
+          <select
+            value={priority}
+            onChange={(e) => setPriority(e.target.value as TaskPriority | '')}
+            className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          >
+            <option value="">未設定</option>
+            <option value="high">高</option>
+            <option value="medium">中</option>
+            <option value="low">低</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">期日</label>
+          <input
+            type="date"
+            value={dueDate}
+            onChange={(e) => setDueDate(e.target.value)}
+            className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          />
+        </div>
+        {error && <p className="text-xs text-red-600">{error}</p>}
+        <div className="flex gap-2 justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-1.5 rounded-full text-sm font-medium bg-white text-gray-600 border border-gray-300 hover:bg-gray-50 transition-colors"
+          >
+            キャンセル
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="px-4 py-1.5 rounded-full text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            {submitting ? '保存中...' : '作成'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -12,3 +12,10 @@ export interface TaskResponse {
   createdAt: string
   updatedAt: string
 }
+
+export interface TaskCreateRequest {
+  title: string
+  description: string | null
+  priority: TaskPriority | null
+  dueDate: string | null
+}


### PR DESCRIPTION
## 概要
- POST /api/tasks エンドポイントを新規実装し、フロントエンドのフォームからタスクを DB に登録できるようにした

## 変更内容

### バックエンド
- `Task.java`: static ファクトリメソッド `create()` を追加
- `TaskRepository.java`: `findTopByOrderByPositionDesc()` を追加し、position を自動採番
- `TaskCreateRequest.java`: 新規作成（`@NotBlank` / `@Size` バリデーション付き Record）
- `GlobalExceptionHandler.java`: `MethodArgumentNotValidException` ハンドラーを追加（`@Valid` バリデーションエラーを JSON 400 で返す）
- `TaskService.java`: `create()` メソッドを追加（`@Transactional` で readOnly 上書き）
- `TaskController.java`: `POST /api/tasks` を追加（201 Created + Location ヘッダー）

### フロントエンド
- `types/task.ts`: `TaskCreateRequest` 型を追加
- `api/taskApi.ts`: `createTask()` 関数を追加
- `components/TaskForm.tsx`: 新規作成（title/description/priority/dueDate フォーム）
- `App.tsx`: フォームトグル・`useCallback` による `loadTasks` 切り出し・作成後の再取得

## テスト手順
- [ ] `docker compose up -d` で PostgreSQL 起動
- [ ] `cd backend && ./gradlew bootRun` でバックエンド起動
- [ ] `cd frontend && npm run dev` でフロントエンド起動
- [ ] `http://localhost:5173` を開き「+ 新規タスク」ボタンをクリック
- [ ] title を入力して「作成」→ Todo カラムに新しいタスクが追加されることを確認
- [ ] title 空のまま「作成」→ エラーメッセージが表示されることを確認
- [ ] curl で `POST /api/tasks` を叩き 201 + Location ヘッダーが返ることを確認

Closes #22