### PR TITLE
feat(backend/frontend): タスク削除機能を実装する（物理削除）

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 | Gradle Wrapper | 8.14.4 |
 | Spring Data JPA | Spring Boot 管理 |
 | PostgreSQL ドライバ | Spring Boot 管理 |
-| Lombok | Spring Boot 管理 |
 
 ### フロントエンド
 
@@ -29,6 +28,7 @@
 | Vite | 8.0.10 |
 | Tailwind CSS | 4.2.4 |
 | Axios | 1.15.2 |
+| @hello-pangea/dnd | 17.0.0 |
 
 ### インフラ
 
@@ -63,20 +63,32 @@ TaskManagement/
 ├── backend/                  # Spring Boot アプリケーション
 │   └── src/main/java/com/example/taskmanagement/
 │       ├── config/           # CorsConfig
-│       ├── controller/       # TaskController (GET・POST /api/tasks)
+│       ├── controller/       # TaskController
 │       ├── domain/           # Task エンティティ、Priority / Status 列挙
-│       ├── dto/              # TaskResponse, TaskCreateRequest
+│       ├── dto/              # TaskResponse, TaskCreateRequest, TaskUpdateRequest 等
 │       ├── exception/        # GlobalExceptionHandler, TaskNotFoundException
 │       ├── repository/       # TaskRepository (JPA)
 │       └── service/          # TaskService
 ├── frontend/                 # React + Vite アプリケーション
 │   └── src/
 │       ├── api/              # taskApi.ts (Axios)
-│       ├── components/       # Board, Column, TaskCard, FilterBar, TaskForm
+│       ├── components/       # Board, Column, TaskCard, TaskDetailModal, FilterBar, TaskForm
 │       └── types/            # task.ts
 ├── docker-compose.yml        # PostgreSQL 16
 └── CLAUDE.md                 # Claude Code 作業ルール
 ```
+
+---
+
+## 機能一覧
+
+- タスク一覧をカンバンボード（Todo / 進行中 / 完了）形式で表示
+- ステータスでの絞り込みフィルター
+- タスク新規登録（タイトル・説明・優先度・期日）
+- タスク編集（カードクリックでモーダルを開き、内容を更新）
+- ドラッグ&ドロップによるタスクのステータス変更・並び替え
+- タスク削除（確認ダイアログあり）
+- 期日超過の赤色ハイライト表示
 
 ---
 
@@ -119,12 +131,16 @@ npm run dev
 
 | メソッド | パス | 説明 |
 |----------|------|------|
-| GET | `/api/tasks` | 全タスク取得 |
+| GET | `/api/tasks` | 全タスク取得（position 昇順） |
 | GET | `/api/tasks/{id}` | ID 指定でタスク取得 |
 | GET | `/api/tasks/status/{status}` | ステータス絞り込みでタスク取得 |
 | POST | `/api/tasks` | タスク新規登録 |
+| PUT | `/api/tasks/{id}` | タスク内容更新 |
+| PATCH | `/api/tasks/{id}/status` | ステータス変更 |
+| PATCH | `/api/tasks/{id}/position` | 並び順変更 |
+| DELETE | `/api/tasks/{id}` | タスク削除 |
 
-### POST /api/tasks リクエストボディ
+### POST /api/tasks・PUT /api/tasks/{id} リクエストボディ
 
 ```json
 {
@@ -142,7 +158,24 @@ npm run dev
 | `priority` | string \| null | 任意 | `high` / `medium` / `low` |
 | `dueDate` | string \| null | 任意 | `YYYY-MM-DD` 形式 |
 
-`status` は `todo` 固定、`position` はサーバー側で自動採番。成功時は **201 Created** + `Location` ヘッダーを返す。
+POST 成功時は **201 Created** + `Location` ヘッダーを返す。  
+PUT 成功時は **200 OK** を返す。
+
+### PATCH /api/tasks/{id}/status リクエストボディ
+
+```json
+{ "status": "in_progress" }
+```
+
+### PATCH /api/tasks/{id}/position リクエストボディ
+
+```json
+{ "position": 2 }
+```
+
+### DELETE /api/tasks/{id}
+
+成功時は **204 No Content** を返す。存在しない ID の場合は **404 Not Found**。
 
 ### ステータス値
 

--- a/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
@@ -76,4 +76,10 @@ public class TaskController {
             @RequestBody TaskPositionUpdateRequest req) {
         return ResponseEntity.ok(TaskResponse.from(taskService.updatePosition(id, req.position())));
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTask(@PathVariable Long id) {
+        taskService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
@@ -89,4 +89,10 @@ public class TaskService {
         task.updatePosition(position);
         return taskRepository.save(task);
     }
+
+    @Transactional
+    public void delete(Long id) {
+        findById(id);
+        taskRepository.deleteById(id);
+    }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,6 +44,10 @@ export default function App() {
     setTasks(reordered)
   }
 
+  const handleDeleted = (id: number) => {
+    setTasks(prev => prev.filter(t => t.id !== id))
+  }
+
   return (
     <div className="min-h-screen bg-gray-100">
       <header className="bg-white border-b border-gray-200 px-6 py-4">
@@ -76,7 +80,7 @@ export default function App() {
           <p className="text-sm text-red-600">{error}</p>
         )}
 
-        {!loading && !error && <Board tasks={tasks} onUpdated={handleUpdated} onReordered={handleReordered} />}
+        {!loading && !error && <Board tasks={tasks} onUpdated={handleUpdated} onReordered={handleReordered} onDeleted={handleDeleted} />}
       </main>
     </div>
   )

--- a/frontend/src/api/taskApi.ts
+++ b/frontend/src/api/taskApi.ts
@@ -32,3 +32,7 @@ export async function updateTaskPosition(id: number, position: number): Promise<
   const res = await api.patch<TaskResponse>(`/tasks/${id}/position`, { position })
   return res.data
 }
+
+export async function deleteTask(id: number): Promise<void> {
+  await api.delete(`/tasks/${id}`)
+}

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -7,6 +7,7 @@ interface Props {
   tasks: TaskResponse[]
   onUpdated: (task: TaskResponse) => void
   onReordered: (tasks: TaskResponse[]) => void
+  onDeleted: (id: number) => void
 }
 
 const COLUMNS: { status: TaskStatus; label: string; colorClass: string }[] = [
@@ -15,7 +16,7 @@ const COLUMNS: { status: TaskStatus; label: string; colorClass: string }[] = [
   { status: 'done', label: '完了', colorClass: 'bg-green-400' },
 ]
 
-export default function Board({ tasks, onUpdated, onReordered }: Props) {
+export default function Board({ tasks, onUpdated, onReordered, onDeleted }: Props) {
   const handleDragEnd = async (result: DropResult) => {
     const { source, destination, draggableId } = result
     if (!destination) return
@@ -81,6 +82,7 @@ export default function Board({ tasks, onUpdated, onReordered }: Props) {
               .filter((t) => t.status === col.status)
               .sort((a, b) => a.position - b.position)}
             onUpdated={onUpdated}
+            onDeleted={onDeleted}
           />
         ))}
       </div>

--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -8,9 +8,10 @@ interface Props {
   tasks: TaskResponse[]
   colorClass: string
   onUpdated: (task: TaskResponse) => void
+  onDeleted: (id: number) => void
 }
 
-export default function Column({ label, status, tasks, colorClass, onUpdated }: Props) {
+export default function Column({ label, status, tasks, colorClass, onUpdated, onDeleted }: Props) {
   return (
     <div className="flex-1 min-w-0 bg-gray-50 rounded-xl p-3 flex flex-col gap-2">
       <div className="flex items-center gap-2 pb-2 border-b border-gray-200">
@@ -30,7 +31,7 @@ export default function Column({ label, status, tasks, colorClass, onUpdated }: 
             }`}
           >
             {tasks.map((task, index) => (
-              <TaskCard key={task.id} task={task} index={index} onUpdated={onUpdated} />
+              <TaskCard key={task.id} task={task} index={index} onUpdated={onUpdated} onDeleted={onDeleted} />
             ))}
             {provided.placeholder}
             {tasks.length === 0 && !snapshot.isDraggingOver && (

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react'
 import { Draggable } from '@hello-pangea/dnd'
 import type { TaskResponse } from '../types/task'
+import { deleteTask } from '../api/taskApi'
 import TaskDetailModal from './TaskDetailModal'
 
 interface Props {
   task: TaskResponse
   index: number
   onUpdated: (task: TaskResponse) => void
+  onDeleted: (id: number) => void
 }
 
 const PRIORITY_BADGE: Record<string, string> = {
@@ -21,11 +23,18 @@ const PRIORITY_LABEL: Record<string, string> = {
   low: '低',
 }
 
-export default function TaskCard({ task, index, onUpdated }: Props) {
+export default function TaskCard({ task, index, onUpdated, onDeleted }: Props) {
   const [modalOpen, setModalOpen] = useState(false)
 
   const today = new Date().toISOString().slice(0, 10)
   const isOverdue = task.dueDate !== null && task.dueDate < today && task.status !== 'done'
+
+  const handleDelete = async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (!window.confirm(`「${task.title}」を削除しますか？`)) return
+    await deleteTask(task.id)
+    onDeleted(task.id)
+  }
 
   return (
     <>
@@ -40,7 +49,16 @@ export default function TaskCard({ task, index, onUpdated }: Props) {
             }`}
             onClick={() => setModalOpen(true)}
           >
-            <p className="text-sm font-medium text-gray-800 leading-snug">{task.title}</p>
+            <div className="flex items-start justify-between gap-2">
+              <p className="text-sm font-medium text-gray-800 leading-snug">{task.title}</p>
+              <button
+                onClick={handleDelete}
+                className="text-gray-300 hover:text-red-500 transition-colors flex-shrink-0 text-base leading-none"
+                title="削除"
+              >
+                🗑
+              </button>
+            </div>
 
             {task.description && (
               <p className="text-xs text-gray-500 truncate">{task.description}</p>


### PR DESCRIPTION
## 概要
タスクカードにゴミ箱ボタンを追加し、確認ダイアログ経由で物理削除できるようにする。

## 変更内容
### バックエンド
- `TaskService.java`: `delete(Long id)` メソッドを追加（存在確認→削除）
- `TaskController.java`: `DELETE /{id}` エンドポイントを追加（204 No Content）

### フロントエンド
- `api/taskApi.ts`: `deleteTask()` 関数を追加
- `TaskCard.tsx`: カード右上にゴミ箱ボタンを追加（確認ダイアログあり、モーダル伝播なし）
- `Column.tsx` / `Board.tsx` / `App.tsx`: `onDeleted` コールバックを通す

## 動作確認
- [ ] ゴミ箱ボタンをクリック → 確認ダイアログが出る
- [ ] OK → カードが即座に消える
- [ ] キャンセル → 何も起きない
- [ ] 存在しないIDへの DELETE → 404 が返る

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)