### PR TITLE
refactor: 設計書に準拠するよう実装を修正し品質を向上させる

### DIFF
--- a/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/example/taskmanagement/controller/TaskController.java
@@ -73,7 +73,7 @@ public class TaskController {
     @PatchMapping("/{id}/position")
     public ResponseEntity<TaskResponse> updateTaskPosition(
             @PathVariable Long id,
-            @RequestBody TaskPositionUpdateRequest req) {
+            @RequestBody @Valid TaskPositionUpdateRequest req) {
         return ResponseEntity.ok(TaskResponse.from(taskService.updatePosition(id, req.position())));
     }
 

--- a/backend/src/main/java/com/example/taskmanagement/dto/TaskPositionUpdateRequest.java
+++ b/backend/src/main/java/com/example/taskmanagement/dto/TaskPositionUpdateRequest.java
@@ -1,5 +1,8 @@
 package com.example.taskmanagement.dto;
 
+import jakarta.validation.constraints.Min;
+
 public record TaskPositionUpdateRequest(
+    @Min(value = 1, message = "ポジションは1以上である必要があります")
     int position
 ) {}

--- a/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/example/taskmanagement/service/TaskService.java
@@ -33,7 +33,12 @@ public class TaskService {
     }
 
     public List<Task> findByStatus(String status) {
-        Status s = Status.valueOf(status);
+        Status s;
+        try {
+            s = Status.valueOf(status);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("無効なステータスです: " + status);
+        }
         return taskRepository.findByStatusOrderByPositionAsc(s);
     }
 

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -32,8 +32,12 @@ export default function TaskCard({ task, index, onUpdated, onDeleted }: Props) {
   const handleDelete = async (e: React.MouseEvent) => {
     e.stopPropagation()
     if (!window.confirm(`「${task.title}」を削除しますか？`)) return
-    await deleteTask(task.id)
-    onDeleted(task.id)
+    try {
+      await deleteTask(task.id)
+      onDeleted(task.id)
+    } catch {
+      alert('タスクの削除に失敗しました')
+    }
   }
 
   return (

--- a/frontend/src/components/TaskDetailModal.tsx
+++ b/frontend/src/components/TaskDetailModal.tsx
@@ -66,10 +66,11 @@ export default function TaskDetailModal({ task, onClose, onUpdated }: Props) {
 
         <form onSubmit={handleSubmit} className="space-y-3">
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">
+            <label htmlFor="edit-title" className="block text-xs font-medium text-gray-600 mb-1">
               タイトル <span className="text-red-500">*</span>
             </label>
             <input
+              id="edit-title"
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
@@ -79,8 +80,9 @@ export default function TaskDetailModal({ task, onClose, onUpdated }: Props) {
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">説明</label>
+            <label htmlFor="edit-description" className="block text-xs font-medium text-gray-600 mb-1">説明</label>
             <textarea
+              id="edit-description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={3}
@@ -89,8 +91,9 @@ export default function TaskDetailModal({ task, onClose, onUpdated }: Props) {
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">優先度</label>
+            <label htmlFor="edit-priority" className="block text-xs font-medium text-gray-600 mb-1">優先度</label>
             <select
+              id="edit-priority"
               value={priority}
               onChange={(e) => setPriority(e.target.value as TaskPriority | '')}
               className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
@@ -103,8 +106,9 @@ export default function TaskDetailModal({ task, onClose, onUpdated }: Props) {
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">期日</label>
+            <label htmlFor="edit-due-date" className="block text-xs font-medium text-gray-600 mb-1">期日</label>
             <input
+              id="edit-due-date"
               type="date"
               value={dueDate}
               onChange={(e) => setDueDate(e.target.value)}

--- a/frontend/src/components/TaskForm.tsx
+++ b/frontend/src/components/TaskForm.tsx
@@ -47,10 +47,11 @@ export default function TaskForm({ onClose, onCreated }: Props) {
       <h2 className="text-sm font-bold text-gray-800 mb-4">新規タスク</h2>
       <form onSubmit={handleSubmit} className="space-y-3">
         <div>
-          <label className="block text-xs font-medium text-gray-600 mb-1">
+          <label htmlFor="new-title" className="block text-xs font-medium text-gray-600 mb-1">
             タイトル <span className="text-red-500">*</span>
           </label>
           <input
+            id="new-title"
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
@@ -59,8 +60,9 @@ export default function TaskForm({ onClose, onCreated }: Props) {
           />
         </div>
         <div>
-          <label className="block text-xs font-medium text-gray-600 mb-1">説明</label>
+          <label htmlFor="new-description" className="block text-xs font-medium text-gray-600 mb-1">説明</label>
           <textarea
+            id="new-description"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             rows={3}
@@ -68,8 +70,9 @@ export default function TaskForm({ onClose, onCreated }: Props) {
           />
         </div>
         <div>
-          <label className="block text-xs font-medium text-gray-600 mb-1">優先度</label>
+          <label htmlFor="new-priority" className="block text-xs font-medium text-gray-600 mb-1">優先度</label>
           <select
+            id="new-priority"
             value={priority}
             onChange={(e) => setPriority(e.target.value as TaskPriority | '')}
             className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-400"
@@ -81,8 +84,9 @@ export default function TaskForm({ onClose, onCreated }: Props) {
           </select>
         </div>
         <div>
-          <label className="block text-xs font-medium text-gray-600 mb-1">期日</label>
+          <label htmlFor="new-due-date" className="block text-xs font-medium text-gray-600 mb-1">期日</label>
           <input
+            id="new-due-date"
             type="date"
             value={dueDate}
             onChange={(e) => setDueDate(e.target.value)}


### PR DESCRIPTION
## 概要

設計書（要件定義書・API仕様書・画面設計書）を正とし、実装の不足・不整合を6箇所修正する。

## 修正内容

### バックエンド

- `TaskPositionUpdateRequest` に `@Min(1)` バリデーションを追加（要件定義書 3.4 準拠）
- `TaskController#updateTaskPosition` のリクエストボディに `@Valid` を追加してバリデーションを有効化
- `TaskService#findByStatus` の不正ステータスエラーメッセージを「無効なステータスです: {status}」に統一（API仕様書準拠）

### フロントエンド

- `TaskForm` の全フォームフィールドに `id` 属性を付与し `<label htmlFor>` と対応付け（画面設計書 3.3・要件定義書 3.6 準拠）
- `TaskDetailModal` の全フォームフィールドに `id` 属性を付与し `<label htmlFor>` と対応付け（画面設計書 3.7 準拠）
- `TaskCard` の削除失敗時に `alert()` でエラー通知（要件定義書 FR-04 準拠）

## テスト計画

- [ ] フロントエンドビルドが成功する（`npm run build`）
- [ ] バックエンドビルドが成功する（`./gradlew build -x test`）
- [ ] `PATCH /api/tasks/{id}/position` に `position=0` を送ると 400 が返る
- [ ] `GET /api/tasks/status/invalid_status` に 400 とメッセージ「無効なステータスです: invalid_status」が返る
- [ ] タスク登録フォームのラベルをクリックするとフォームフィールドにフォーカスが当たる
- [ ] タスク編集モーダルのラベルをクリックするとフォームフィールドにフォーカスが当たる
- [ ] タスク削除失敗時にアラートダイアログが表示される

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)