### PR TITLE
feat(infra): Terraform + AWS CLI によるAWSデプロイ基盤を構築する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 backend_tmp/
 backend_tmp.zip
+
+# Terraform
+terraform/.terraform/
+terraform/**/*.tfstate
+terraform/**/*.tfstate.backup
+terraform/**/*.tfvars
+terraform/**/.terraform.lock.hcl

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/backend/src/main/java/com/example/taskmanagement/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/taskmanagement/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.POST, "/api/auth/register", "/api/auth/login").permitAll()
+                .requestMatchers("/actuator/health").permitAll()
                 .anyRequest().authenticated()
             )
             .authenticationProvider(authenticationProvider)
@@ -51,7 +52,8 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        String corsOrigin = System.getenv().getOrDefault("CORS_ALLOWED_ORIGIN", "http://localhost:5173");
+        config.setAllowedOrigins(List.of(corsOrigin));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -26,3 +26,12 @@ server:
 jwt:
   secret: ${JWT_SECRET:taskmanagement-jwt-secret-key-must-be-at-least-256-bits-long}
   expiration-ms: ${JWT_EXPIRATION_MS:86400000}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/docs/aws-deploy.md
+++ b/docs/aws-deploy.md
@@ -1,0 +1,323 @@
+# AWS デプロイ手順書
+
+AWS + Terraform + AWS CLI を使って TaskManagement を本番環境にデプロイする手順です。
+**AWS・Terraform 未経験者向けに解説を含めています。**
+
+---
+
+## 概念解説
+
+### IaC（Infrastructure as Code）とは
+
+インフラ（サーバー・DB・ネットワーク等）をコードで定義し、Git で管理できるようにする考え方です。
+「AWS マネジメントコンソールで手動設定する」代わりに、コードを書いて `terraform apply` を実行するだけで
+同じ環境が何度でも再現できます。
+
+### Terraform とは
+
+IaC を実現するツールです。HCL（HashiCorp Configuration Language）という記法で AWS リソースを定義します。
+
+```
+terraform init   → プラグインのダウンロード（初回のみ）
+terraform plan   → 「今から何を作るか」を表示（実際には何も変わらない）
+terraform apply  → 実際にリソースを作成・変更
+terraform destroy → すべてのリソースを削除（後片付け）
+```
+
+### 今回のアーキテクチャ
+
+```
+Internet
+  │
+  ├──► ALB (HTTP:80) ──► EC2 t3.micro (Spring Boot:8080)
+  │                              │
+  └──► S3 + CloudFront (HTTPS)  RDS PostgreSQL db.t3.micro
+  （React SPA 静的ファイル）      （プライベートサブネット内）
+
+VPC 10.0.0.0/16
+  ├── パブリックサブネット  10.0.1.0/24 (ap-northeast-1a) ← EC2, ALB
+  ├── パブリックサブネット  10.0.2.0/24 (ap-northeast-1c) ← ALB 用（マルチAZ必須）
+  ├── プライベートサブネット 10.0.10.0/24 (ap-northeast-1a) ← RDS
+  └── プライベートサブネット 10.0.11.0/24 (ap-northeast-1c) ← RDS Subnet Group
+```
+
+### AWS 用語早見表
+
+| 用語 | 説明 |
+|------|------|
+| VPC | AWS 内の独立したネットワーク空間 |
+| サブネット | VPC を分割したネットワーク。パブリック（インターネット到達可）とプライベート（不可）がある |
+| Security Group | EC2・RDS への通信を許可・拒否するファイアウォール |
+| IGW（Internet Gateway） | VPC からインターネットへの出口 |
+| ALB（Application Load Balancer） | トラフィックを EC2 に転送するロードバランサー |
+| IAM Role | EC2 等に与える「権限セット」。Secrets Manager へのアクセスに使う |
+| Secrets Manager | パスワード・API キーを安全に保管するサービス |
+| RDS | AWS が管理するマネージド DB サービス |
+| S3 | オブジェクトストレージ。静的ファイルを置く場所 |
+| CloudFront | CDN。S3 の前段に配置してキャッシュ・HTTPS を提供 |
+
+---
+
+## Phase 0: 事前準備
+
+### Step 1: AWS CLI のインストールと設定
+
+```bash
+# macOS
+brew install awscli
+
+# AWS コンソールで IAM ユーザーのアクセスキーを取得してから実行
+# IAM → ユーザー → セキュリティ認証情報 → アクセスキー作成（CLI 用）
+aws configure
+# AWS Access Key ID: [取得したキー ID]
+# AWS Secret Access Key: [取得したシークレットキー]
+# Default region name: ap-northeast-1
+# Default output format: json
+
+# 設定が正しいか確認（自分のアカウント情報が表示されれば OK）
+aws sts get-caller-identity
+```
+
+### Step 2: Terraform のインストール
+
+```bash
+brew tap hashicorp/tap
+brew install hashicorp/tap/terraform
+
+# バージョン確認（1.9.x 以上であれば OK）
+terraform version
+```
+
+### Step 3: EC2 SSH キーペアの作成
+
+```bash
+# ローカルに SSH キーを生成
+ssh-keygen -t ed25519 -f ~/.ssh/taskmanagement-prod -N ""
+
+# AWS に公開鍵を登録
+aws ec2 import-key-pair \
+  --key-name "taskmanagement-prod" \
+  --public-key-material fileb://~/.ssh/taskmanagement-prod.pub \
+  --region ap-northeast-1
+
+# 秘密鍵のパーミッション制限（SSH 接続時に必要）
+chmod 600 ~/.ssh/taskmanagement-prod
+```
+
+---
+
+## Phase 1: Terraform で AWS インフラを構築
+
+### Step 1: 変数ファイルの作成
+
+```bash
+cd terraform/
+
+# サンプルをコピー
+cp terraform.tfvars.example terraform.tfvars
+
+# terraform.tfvars を編集して実際の値を設定
+# ※ このファイルは .gitignore で Git 管理対象外です（パスワードが含まれるため）
+```
+
+`terraform.tfvars` に設定する値：
+
+| 変数 | 説明 | 設定例 |
+|------|------|--------|
+| `db_password` | DB パスワード（強力な値を設定） | `MyStr0ngP@ssword!` |
+| `jwt_secret` | JWT 署名鍵（256 ビット以上のランダム文字列） | `openssl rand -hex 32` で生成 |
+| `ec2_key_pair_name` | Step 3 で登録したキーペア名 | `taskmanagement-prod` |
+| `my_ip_cidr` | SSH を許可する自分の IP | `curl ifconfig.me` で確認して `/32` を付ける |
+
+```bash
+# JWT シークレットの生成例
+openssl rand -hex 32
+```
+
+### Step 2: Terraform の実行
+
+```bash
+# プラグインをダウンロード（初回のみ）
+terraform init
+
+# 何が作られるか確認（実際には何も変わらない）
+terraform plan
+
+# インフラを作成（"yes" を入力して実行）
+# RDS の作成に 5〜10 分かかります
+terraform apply
+
+# 作成されたリソースの情報を確認
+terraform output
+```
+
+---
+
+## Phase 2: バックエンド（Spring Boot）のデプロイ
+
+```bash
+# ローカルで JAR をビルド
+cd backend/
+./gradlew bootJar
+
+# terraform output から各値を取得
+cd ../terraform/
+EC2_IP=$(terraform output -raw ec2_public_ip)
+ALB_DNS=$(terraform output -raw alb_dns_name)
+RDS_ENDPOINT=$(terraform output -raw rds_endpoint)
+DB_PASS=$(terraform output -raw db_password)
+DB_USER=$(terraform output -raw db_username)
+JWT=$(terraform output -raw jwt_secret)
+
+# JAR を EC2 に転送
+scp -i ~/.ssh/taskmanagement-prod \
+  ../backend/build/libs/taskmanagement-*.jar \
+  ec2-user@${EC2_IP}:/opt/taskmanagement/app.jar
+
+# EC2 上に環境変数ファイルを作成してサービスを起動
+ssh -i ~/.ssh/taskmanagement-prod ec2-user@${EC2_IP} "
+cat > /opt/taskmanagement/.env << 'ENVEOF'
+DB_URL=jdbc:postgresql://${RDS_ENDPOINT}:5432/taskmanagement
+DB_USERNAME=${DB_USER}
+DB_PASSWORD=${DB_PASS}
+JWT_SECRET=${JWT}
+JPA_DDL_AUTO=update
+CORS_ALLOWED_ORIGIN=http://${ALB_DNS}
+ENVEOF
+sudo systemctl start taskmanagement
+sudo systemctl status taskmanagement
+"
+
+# ヘルスチェック
+curl http://${ALB_DNS}/actuator/health
+# → {"status":"UP"} が返れば成功
+```
+
+---
+
+## Phase 3: フロントエンド（React）のデプロイ
+
+```bash
+cd ../terraform/
+ALB_DNS=$(terraform output -raw alb_dns_name)
+S3_BUCKET=$(terraform output -raw s3_bucket_name)
+CF_ID=$(terraform output -raw cloudfront_distribution_id)
+CF_URL=$(terraform output -raw cloudfront_url)
+
+# ALB の URL を API エンドポイントとして本番ビルド
+cd ../frontend/
+VITE_API_BASE_URL=http://${ALB_DNS} npm run build
+
+# ビルド結果を S3 にアップロード
+aws s3 sync dist/ s3://${S3_BUCKET}/ --delete
+
+# CloudFront のキャッシュを無効化（即時反映）
+aws cloudfront create-invalidation \
+  --distribution-id ${CF_ID} \
+  --paths "/*"
+
+echo "フロントエンドの URL: https://${CF_URL}"
+```
+
+---
+
+## Phase 4: 動作確認
+
+```bash
+cd terraform/
+ALB_DNS=$(terraform output -raw alb_dns_name)
+CF_URL=$(terraform output -raw cloudfront_url)
+
+# 1. バックエンドのヘルスチェック
+curl http://${ALB_DNS}/actuator/health
+# → {"status":"UP"}
+
+# 2. ユーザー登録のテスト
+curl -X POST http://${ALB_DNS}/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"username":"testuser","password":"testpass123"}'
+
+# 3. ブラウザでフロントエンドを開く
+echo "https://${CF_URL}"
+```
+
+---
+
+## バックエンドの更新手順
+
+コードを修正した後の再デプロイ：
+
+```bash
+# 再ビルド
+cd backend/
+./gradlew bootJar
+
+# EC2 に転送して再起動
+cd ../terraform/
+EC2_IP=$(terraform output -raw ec2_public_ip)
+scp -i ~/.ssh/taskmanagement-prod \
+  ../backend/build/libs/taskmanagement-*.jar \
+  ec2-user@${EC2_IP}:/opt/taskmanagement/app.jar
+ssh -i ~/.ssh/taskmanagement-prod ec2-user@${EC2_IP} "sudo systemctl restart taskmanagement"
+```
+
+## フロントエンドの更新手順
+
+```bash
+cd frontend/
+cd ../terraform/
+ALB_DNS=$(terraform output -raw alb_dns_name)
+S3_BUCKET=$(terraform output -raw s3_bucket_name)
+CF_ID=$(terraform output -raw cloudfront_distribution_id)
+
+cd ../frontend/
+VITE_API_BASE_URL=http://${ALB_DNS} npm run build
+aws s3 sync dist/ s3://${S3_BUCKET}/ --delete
+aws cloudfront create-invalidation --distribution-id ${CF_ID} --paths "/*"
+```
+
+---
+
+## 後片付け（AWS リソースの全削除）
+
+学習が終わったらリソースを削除して課金を止めます：
+
+```bash
+cd terraform/
+terraform destroy
+# "yes" を入力 → すべての AWS リソースが削除される
+```
+
+---
+
+## トラブルシューティング
+
+### Spring Boot が起動しない
+
+```bash
+# EC2 に SSH してログを確認
+ssh -i ~/.ssh/taskmanagement-prod ec2-user@${EC2_IP}
+sudo journalctl -u taskmanagement -f
+```
+
+### ALB ヘルスチェックが失敗する
+
+1. EC2 のサービスが起動しているか確認: `sudo systemctl status taskmanagement`
+2. 8080 ポートで起動しているか確認: `curl localhost:8080/actuator/health`
+3. Security Group の 8080 ポートが ALB から許可されているか確認
+
+### RDS に接続できない
+
+1. EC2 から RDS エンドポイントへの接続テスト:
+   ```bash
+   # EC2 に SSH してから実行
+   dnf install -y postgresql15
+   psql -h ${RDS_ENDPOINT} -U taskuser -d taskmanagement
+   ```
+2. Security Group で EC2 SG からの 5432 が許可されているか確認
+3. `.env` の `DB_URL` が正しいか確認
+
+### フロントエンドで API エラーが出る
+
+ブラウザの開発者ツール（Network タブ）で API リクエストの向き先を確認。
+`VITE_API_BASE_URL` が正しく設定されてビルドされているかを確認する。

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,7 @@
 import axios from 'axios'
 
-const api = axios.create({ baseURL: '/api' })
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+const api = axios.create({ baseURL: `${API_BASE_URL}/api` })
 
 export default api

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,63 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      Environment = var.environment
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+module "vpc" {
+  source       = "./modules/vpc"
+  project_name = var.project_name
+}
+
+module "security_groups" {
+  source       = "./modules/security_groups"
+  project_name = var.project_name
+  vpc_id       = module.vpc.vpc_id
+  my_ip_cidr   = var.my_ip_cidr
+}
+
+module "secrets" {
+  source       = "./modules/secrets"
+  project_name = var.project_name
+  db_username  = var.db_username
+  db_password  = var.db_password
+  jwt_secret   = var.jwt_secret
+}
+
+module "rds" {
+  source             = "./modules/rds"
+  project_name       = var.project_name
+  db_username        = var.db_username
+  db_password        = var.db_password
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [module.security_groups.rds_sg_id]
+}
+
+module "ec2" {
+  source             = "./modules/ec2"
+  project_name       = var.project_name
+  subnet_id          = module.vpc.public_subnet_ids[0]
+  security_group_ids = [module.security_groups.ec2_sg_id]
+  key_pair_name      = var.ec2_key_pair_name
+  aws_region         = var.aws_region
+}
+
+module "alb" {
+  source             = "./modules/alb"
+  project_name       = var.project_name
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.public_subnet_ids
+  security_group_ids = [module.security_groups.alb_sg_id]
+  ec2_instance_id    = module.ec2.instance_id
+}
+
+module "frontend" {
+  source       = "./modules/frontend"
+  project_name = var.project_name
+}

--- a/terraform/modules/alb/main.tf
+++ b/terraform/modules/alb/main.tf
@@ -1,0 +1,60 @@
+# ALB（Application Load Balancer）
+# 受信トラフィックを EC2 に転送するロードバランサー。
+# HTTPS 終端（SSL 証明書の管理）も担えるが、今回は HTTP のみの構成。
+
+resource "aws_lb" "main" {
+  name               = "${var.project_name}-alb"
+  internal           = false # インターネット向け（external）
+  load_balancer_type = "application"
+  security_groups    = var.security_group_ids
+  subnets            = var.subnet_ids # ALB はマルチ AZ 必須
+
+  tags = {
+    Name = "${var.project_name}-alb"
+  }
+}
+
+# ターゲットグループ：ALB がリクエストを転送する先の定義
+resource "aws_lb_target_group" "backend" {
+  name     = "${var.project_name}-tg"
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = var.vpc_id
+
+  # ヘルスチェック：EC2 が正常に動いているかを定期確認
+  # /actuator/health は Spring Boot Actuator が提供するエンドポイント
+  health_check {
+    enabled             = true
+    path                = "/actuator/health"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+    timeout             = 10
+    matcher             = "200"
+  }
+
+  tags = {
+    Name = "${var.project_name}-tg"
+  }
+}
+
+# リスナー：ALB がポート 80 (HTTP) で受け付けた通信をターゲットグループに転送
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
+  }
+}
+
+# EC2 インスタンスをターゲットグループに登録
+resource "aws_lb_target_group_attachment" "ec2" {
+  target_group_arn = aws_lb_target_group.backend.arn
+  target_id        = var.ec2_instance_id
+  port             = 8080
+}

--- a/terraform/modules/alb/outputs.tf
+++ b/terraform/modules/alb/outputs.tf
@@ -1,0 +1,4 @@
+output "alb_dns_name" {
+  description = "ALB の DNS 名（API エンドポイントとして使用）"
+  value       = aws_lb.main.dns_name
+}

--- a/terraform/modules/alb/variables.tf
+++ b/terraform/modules/alb/variables.tf
@@ -1,0 +1,20 @@
+variable "project_name" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "ALB を配置するパブリックサブネット ID（2つ以上必要）"
+}
+
+variable "security_group_ids" {
+  type = list(string)
+}
+
+variable "ec2_instance_id" {
+  type = string
+}

--- a/terraform/modules/ec2/main.tf
+++ b/terraform/modules/ec2/main.tf
@@ -1,0 +1,79 @@
+# Amazon Linux 2023 の最新 AMI を動的に取得
+# AMI ID はリージョンやアップデートで変わるため、ハードコードせず data source で取得する
+data "aws_ami" "amazon_linux_2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# EC2 に Secrets Manager 読み取り権限を付与する IAM ロール
+# IAM ロール：EC2 がどの AWS サービスにアクセスできるかを定義する「権限セット」
+resource "aws_iam_role" "ec2_role" {
+  name = "${var.project_name}-ec2-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "secrets_manager_read" {
+  name = "${var.project_name}-secrets-read"
+  role = aws_iam_role.ec2_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = "arn:aws:secretsmanager:${var.aws_region}:*:secret:${var.project_name}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_instance_profile" "ec2_profile" {
+  name = "${var.project_name}-ec2-profile"
+  role = aws_iam_role.ec2_role.name
+}
+
+# EC2 インスタンス
+resource "aws_instance" "main" {
+  ami                    = data.aws_ami.amazon_linux_2023.id
+  instance_type          = "t3.micro"
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = var.security_group_ids
+  key_name               = var.key_pair_name
+  iam_instance_profile   = aws_iam_instance_profile.ec2_profile.name
+
+  # user_data：EC2 起動時に一度だけ実行されるシェルスクリプト
+  # Java のインストールと systemd サービスの設定を行う
+  user_data = templatefile("${path.module}/user_data.sh", {
+    project_name = var.project_name
+    aws_region   = var.aws_region
+  })
+
+  tags = {
+    Name = "${var.project_name}-server"
+  }
+}

--- a/terraform/modules/ec2/outputs.tf
+++ b/terraform/modules/ec2/outputs.tf
@@ -1,0 +1,8 @@
+output "instance_id" {
+  value = aws_instance.main.id
+}
+
+output "public_ip" {
+  description = "EC2 パブリック IP（JAR デプロイ・SSH 接続用）"
+  value       = aws_instance.main.public_ip
+}

--- a/terraform/modules/ec2/user_data.sh
+++ b/terraform/modules/ec2/user_data.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+# Amazon Linux 2023 に Java 21 をインストール
+dnf install -y java-21-amazon-corretto
+
+# アプリケーションディレクトリを作成
+mkdir -p /opt/taskmanagement
+
+# ec2-user がアプリディレクトリを所有できるようにする
+chown ec2-user:ec2-user /opt/taskmanagement
+
+# systemd サービスファイルを作成
+# systemd：Linux のサービス管理ツール。自動起動・クラッシュ時の自動再起動などを担う
+cat > /etc/systemd/system/taskmanagement.service << 'EOF'
+[Unit]
+Description=TaskManagement Backend (Spring Boot)
+After=network.target
+
+[Service]
+Type=simple
+User=ec2-user
+WorkingDirectory=/opt/taskmanagement
+EnvironmentFile=/opt/taskmanagement/.env
+ExecStart=/usr/bin/java -jar /opt/taskmanagement/app.jar
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# サービスを有効化（次回起動時に自動スタートするように）
+# ※ JAR ファイルがまだないため、この時点では start しない
+systemctl daemon-reload
+systemctl enable taskmanagement
+
+echo "user_data setup complete"

--- a/terraform/modules/ec2/variables.tf
+++ b/terraform/modules/ec2/variables.tf
@@ -1,0 +1,21 @@
+variable "project_name" {
+  type = string
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "EC2 を配置するパブリックサブネット ID"
+}
+
+variable "security_group_ids" {
+  type = list(string)
+}
+
+variable "key_pair_name" {
+  type        = string
+  description = "EC2 SSH 接続に使うキーペア名"
+}
+
+variable "aws_region" {
+  type = string
+}

--- a/terraform/modules/frontend/main.tf
+++ b/terraform/modules/frontend/main.tf
@@ -1,0 +1,133 @@
+# S3 + CloudFront でフロントエンド（React SPA）を配信する構成
+#
+# S3：オブジェクトストレージ。npm run build で生成した dist/ ファイルを置く場所。
+# CloudFront：CDN（コンテンツデリバリーネットワーク）。
+#   S3 の前段に配置してキャッシュ・HTTPS を提供する。
+#   OAC（Origin Access Control）により、CloudFront 経由のアクセスのみ S3 に届く。
+
+resource "aws_s3_bucket" "frontend" {
+  bucket = "${var.project_name}-frontend-${random_id.suffix.hex}"
+
+  tags = {
+    Name = "${var.project_name}-frontend"
+  }
+}
+
+# バケット名の衝突を防ぐためのランダムサフィックス
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+# パブリックアクセスを完全にブロック（CloudFront 経由のみ許可する）
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# OAC（Origin Access Control）：CloudFront が S3 にアクセスするための認証設定
+resource "aws_cloudfront_origin_access_control" "frontend" {
+  name                              = "${var.project_name}-oac"
+  description                       = "OAC for ${var.project_name} frontend"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# CloudFront ディストリビューション
+resource "aws_cloudfront_distribution" "frontend" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  comment             = "${var.project_name} frontend"
+
+  origin {
+    domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id                = "S3-${aws_s3_bucket.frontend.id}"
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "S3-${aws_s3_bucket.frontend.id}"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+  }
+
+  # SPA（シングルページアプリ）のルーティング対応
+  # React Router 等で /tasks などのパスに直接アクセスしたとき、
+  # S3 が 403 を返してしまう問題を /index.html にリダイレクトして解決する
+  custom_error_response {
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  # price_class：CloudFront のエッジロケーション（配信拠点）の範囲
+  # PriceClass_200 はアジア・北米・ヨーロッパをカバーし、コストを抑えられる
+  price_class = "PriceClass_200"
+
+  viewer_certificate {
+    cloudfront_default_certificate = true # 独自ドメインなしの場合はデフォルト証明書を使用
+  }
+
+  tags = {
+    Name = "${var.project_name}-cloudfront"
+  }
+}
+
+# S3 バケットポリシー：CloudFront からのアクセスのみ許可
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCloudFrontServicePrincipal"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:GetObject"
+        Resource = "${aws_s3_bucket.frontend.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.frontend.arn
+          }
+        }
+      }
+    ]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.frontend]
+}

--- a/terraform/modules/frontend/outputs.tf
+++ b/terraform/modules/frontend/outputs.tf
@@ -1,0 +1,14 @@
+output "cloudfront_url" {
+  description = "CloudFront ドメイン名（フロントエンドアクセス先）"
+  value       = aws_cloudfront_distribution.frontend.domain_name
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront ディストリビューション ID（キャッシュ無効化に使用）"
+  value       = aws_cloudfront_distribution.frontend.id
+}
+
+output "s3_bucket_name" {
+  description = "フロントエンド静的ファイルを置く S3 バケット名"
+  value       = aws_s3_bucket.frontend.bucket
+}

--- a/terraform/modules/frontend/variables.tf
+++ b/terraform/modules/frontend/variables.tf
@@ -1,0 +1,3 @@
+variable "project_name" {
+  type = string
+}

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -1,0 +1,53 @@
+# RDS（Relational Database Service）
+# AWS が管理するマネージド DB サービス。
+# バックアップ・パッチ適用・フェイルオーバーが自動化される。
+# プライベートサブネットに配置し、インターネットから直接アクセスできないようにする。
+
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.project_name}-db-subnet-group"
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Name = "${var.project_name}-db-subnet-group"
+  }
+}
+
+resource "aws_db_parameter_group" "postgres16" {
+  name   = "${var.project_name}-postgres16"
+  family = "postgres16"
+
+  parameter {
+    name  = "timezone"
+    value = "Asia/Tokyo"
+  }
+
+  tags = {
+    Name = "${var.project_name}-postgres16"
+  }
+}
+
+resource "aws_db_instance" "main" {
+  identifier        = "${var.project_name}-db"
+  engine            = "postgres"
+  engine_version    = "16"
+  instance_class    = "db.t3.micro"
+  allocated_storage = 20
+  storage_type      = "gp2"
+
+  db_name  = "taskmanagement"
+  username = var.db_username
+  password = var.db_password
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = var.security_group_ids
+  parameter_group_name   = aws_db_parameter_group.postgres16.name
+
+  publicly_accessible     = false # インターネットから直接接続不可
+  multi_az                = false # コスト削減（本番では true を推奨）
+  skip_final_snapshot     = true  # 学習用：削除時のスナップショット不要
+  backup_retention_period = 1
+
+  tags = {
+    Name = "${var.project_name}-db"
+  }
+}

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -1,0 +1,5 @@
+output "endpoint" {
+  description = "RDS エンドポイント（ポート番号なし）"
+  value       = aws_db_instance.main.address
+  sensitive   = true
+}

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,0 +1,21 @@
+variable "project_name" {
+  type = string
+}
+
+variable "db_username" {
+  type = string
+}
+
+variable "db_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "プライベートサブネット ID のリスト（2つ以上必要）"
+}
+
+variable "security_group_ids" {
+  type = list(string)
+}

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -1,0 +1,32 @@
+# AWS Secrets Manager
+# DB パスワードや JWT 鍵などのシークレット情報を安全に保管するサービス。
+# EC2 は IAM ロール経由でここから動的に値を取得できるため、
+# パスワードをファイルにハードコードする必要がなくなる。
+
+resource "aws_secretsmanager_secret" "db_credentials" {
+  name                    = "${var.project_name}/db_credentials"
+  description             = "TaskManagement RDS 接続情報"
+  recovery_window_in_days = 0 # 学習用：即時削除を許可（本番では 7〜30 が推奨）
+}
+
+resource "aws_secretsmanager_secret_version" "db_credentials" {
+  secret_id = aws_secretsmanager_secret.db_credentials.id
+  secret_string = jsonencode({
+    username = var.db_username
+    password = var.db_password
+    dbname   = "taskmanagement"
+  })
+}
+
+resource "aws_secretsmanager_secret" "jwt" {
+  name                    = "${var.project_name}/jwt"
+  description             = "TaskManagement JWT 署名鍵"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "jwt" {
+  secret_id = aws_secretsmanager_secret.jwt.id
+  secret_string = jsonencode({
+    JWT_SECRET = var.jwt_secret
+  })
+}

--- a/terraform/modules/secrets/outputs.tf
+++ b/terraform/modules/secrets/outputs.tf
@@ -1,0 +1,7 @@
+output "db_credentials_secret_arn" {
+  value = aws_secretsmanager_secret.db_credentials.arn
+}
+
+output "jwt_secret_arn" {
+  value = aws_secretsmanager_secret.jwt.arn
+}

--- a/terraform/modules/secrets/variables.tf
+++ b/terraform/modules/secrets/variables.tf
@@ -1,0 +1,17 @@
+variable "project_name" {
+  type = string
+}
+
+variable "db_username" {
+  type = string
+}
+
+variable "db_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "jwt_secret" {
+  type      = string
+  sensitive = true
+}

--- a/terraform/modules/security_groups/main.tf
+++ b/terraform/modules/security_groups/main.tf
@@ -1,0 +1,85 @@
+# セキュリティグループ（Security Group）
+# EC2 や RDS への通信を許可・拒否するファイアウォールルール。
+# 「どこから・どのポートへの通信を許すか」を定義する。
+
+# ALB 用 SG：インターネットからの HTTP を受け付ける
+resource "aws_security_group" "alb" {
+  name        = "${var.project_name}-alb-sg"
+  description = "ALB: allow HTTP from internet"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "HTTP from internet"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound"
+  }
+
+  tags = {
+    Name = "${var.project_name}-alb-sg"
+  }
+}
+
+# EC2 用 SG：ALB からの 8080 と自分の IP からの SSH のみ許可
+resource "aws_security_group" "ec2" {
+  name        = "${var.project_name}-ec2-sg"
+  description = "EC2: allow 8080 from ALB, SSH from my IP"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+    description     = "Spring Boot from ALB only"
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.my_ip_cidr]
+    description = "SSH from my IP only"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound (for package install, Secrets Manager access, etc.)"
+  }
+
+  tags = {
+    Name = "${var.project_name}-ec2-sg"
+  }
+}
+
+# RDS 用 SG：EC2 からの PostgreSQL 接続のみ許可
+# インターネットから RDS に直接接続することはできない
+resource "aws_security_group" "rds" {
+  name        = "${var.project_name}-rds-sg"
+  description = "RDS: allow 5432 from EC2 only"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ec2.id]
+    description     = "PostgreSQL from EC2 only"
+  }
+
+  tags = {
+    Name = "${var.project_name}-rds-sg"
+  }
+}

--- a/terraform/modules/security_groups/outputs.tf
+++ b/terraform/modules/security_groups/outputs.tf
@@ -1,0 +1,11 @@
+output "alb_sg_id" {
+  value = aws_security_group.alb.id
+}
+
+output "ec2_sg_id" {
+  value = aws_security_group.ec2.id
+}
+
+output "rds_sg_id" {
+  value = aws_security_group.rds.id
+}

--- a/terraform/modules/security_groups/variables.tf
+++ b/terraform/modules/security_groups/variables.tf
@@ -1,0 +1,12 @@
+variable "project_name" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "my_ip_cidr" {
+  type        = string
+  description = "SSH を許可する IP（例: 1.2.3.4/32）"
+}

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -1,0 +1,111 @@
+# VPC
+# AWS 内の独立したネットワーク空間。外部からの不正アクセスを防ぎ、
+# リソース間の通信を制御するための基盤となる。
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.project_name}-vpc"
+  }
+}
+
+# パブリックサブネット（EC2・ALB を配置）
+# インターネットゲートウェイ経由でインターネットに接続できる
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.project_name}-public-a"
+  }
+}
+
+resource "aws_subnet" "public_c" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.2.0/24"
+  availability_zone       = "ap-northeast-1c"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.project_name}-public-c"
+  }
+}
+
+# プライベートサブネット（RDS を配置）
+# インターネットから直接アクセスできない。EC2 経由のみ。
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.10.0/24"
+  availability_zone = "ap-northeast-1a"
+
+  tags = {
+    Name = "${var.project_name}-private-a"
+  }
+}
+
+resource "aws_subnet" "private_c" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.11.0/24"
+  availability_zone = "ap-northeast-1c"
+
+  tags = {
+    Name = "${var.project_name}-private-c"
+  }
+}
+
+# インターネットゲートウェイ（VPC からインターネットへの出口）
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project_name}-igw"
+  }
+}
+
+# パブリックサブネット用ルートテーブル（IGW 経由でインターネットへ）
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public_a" {
+  subnet_id      = aws_subnet.public_a.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public_c" {
+  subnet_id      = aws_subnet.public_c.id
+  route_table_id = aws_route_table.public.id
+}
+
+# プライベートサブネット用ルートテーブル（インターネットへの経路なし）
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project_name}-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "private_a" {
+  subnet_id      = aws_subnet.private_a.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "private_c" {
+  subnet_id      = aws_subnet.private_c.id
+  route_table_id = aws_route_table.private.id
+}

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  value = [aws_subnet.public_a.id, aws_subnet.public_c.id]
+}
+
+output "private_subnet_ids" {
+  value = [aws_subnet.private_a.id, aws_subnet.private_c.id]
+}

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,0 +1,3 @@
+variable "project_name" {
+  type = string
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,48 @@
+output "alb_dns_name" {
+  description = "ALB の DNS 名（バックエンド API エンドポイント）"
+  value       = module.alb.alb_dns_name
+}
+
+output "cloudfront_url" {
+  description = "CloudFront の URL（フロントエンドアクセス先）"
+  value       = module.frontend.cloudfront_url
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront ディストリビューション ID（キャッシュ無効化に使用）"
+  value       = module.frontend.cloudfront_distribution_id
+}
+
+output "s3_bucket_name" {
+  description = "フロントエンド静的ファイルを置く S3 バケット名"
+  value       = module.frontend.s3_bucket_name
+}
+
+output "ec2_public_ip" {
+  description = "EC2 インスタンスのパブリック IP（JAR デプロイ・SSH 接続に使用）"
+  value       = module.ec2.public_ip
+}
+
+output "rds_endpoint" {
+  description = "RDS エンドポイント（DB_URL 環境変数に設定する）"
+  value       = module.rds.endpoint
+  sensitive   = true
+}
+
+output "db_username" {
+  description = "DB ユーザー名"
+  value       = var.db_username
+  sensitive   = true
+}
+
+output "db_password" {
+  description = "DB パスワード"
+  value       = var.db_password
+  sensitive   = true
+}
+
+output "jwt_secret" {
+  description = "JWT 署名鍵"
+  value       = var.jwt_secret
+  sensitive   = true
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,12 @@
+# このファイルを terraform.tfvars にコピーして実際の値を入力してください
+# terraform.tfvars は .gitignore で Git 管理対象外になっています
+
+aws_region        = "ap-northeast-1"
+project_name      = "taskmanagement"
+db_username       = "taskuser"
+db_password       = "CHANGE_ME_STRONG_PASSWORD_HERE"
+jwt_secret        = "CHANGE_ME_256BIT_RANDOM_STRING_HERE"
+ec2_key_pair_name = "taskmanagement-prod"
+
+# 自分のグローバル IP を確認: curl ifconfig.me
+my_ip_cidr = "YOUR_GLOBAL_IP/32"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,44 @@
+variable "aws_region" {
+  description = "AWSリージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "project_name" {
+  description = "プロジェクト名（リソース命名に使用）"
+  type        = string
+  default     = "taskmanagement"
+}
+
+variable "environment" {
+  description = "環境名"
+  type        = string
+  default     = "production"
+}
+
+variable "db_username" {
+  description = "RDS の DB ユーザー名"
+  type        = string
+}
+
+variable "db_password" {
+  description = "RDS の DB パスワード（強力な値を設定すること）"
+  type        = string
+  sensitive   = true
+}
+
+variable "jwt_secret" {
+  description = "JWT 署名鍵（256 ビット以上のランダム文字列）"
+  type        = string
+  sensitive   = true
+}
+
+variable "ec2_key_pair_name" {
+  description = "EC2 SSH 接続に使うキーペア名（aws ec2 import-key-pair で登録済みのもの）"
+  type        = string
+}
+
+variable "my_ip_cidr" {
+  description = "SSH を許可する自分の IP（例: 1.2.3.4/32）。curl ifconfig.me で確認できる"
+  type        = string
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
## 概要

AWS/Terraform 未経験者でも手順に従って本番デプロイができるよう、Terraform IaC 基盤とデプロイ手順書を追加します。

- マネジメントコンソールの手動操作なし、AWS CLI + `terraform apply` のみでインフラを構築可能
- コスト最小化構成: EC2 t3.micro + RDS db.t3.micro (無料枠対象) + ALB + S3/CloudFront

## アーキテクチャ

```
Internet
  ├──► ALB (HTTP:80) ──► EC2 t3.micro (Spring Boot:8080)
  │                              │
  └──► S3 + CloudFront          RDS PostgreSQL db.t3.micro
       （React SPA）              （プライベートサブネット内）
```

## 変更内容

### アプリコード修正
- `SecurityConfig.java`: CORS `allowedOrigins` を環境変数 `CORS_ALLOWED_ORIGIN` で制御（本番ドメイン対応）
- `application.yml`: ALB ヘルスチェック用に `/actuator/health` エンドポイントを追加
- `build.gradle`: `spring-boot-starter-actuator` 依存関係を追加
- `frontend/src/api/client.ts`: `VITE_API_BASE_URL` 環境変数で API エンドポイントを切り替え可能に
- `.gitignore`: Terraform 機密ファイル (`.terraform/`, `*.tfstate`, `*.tfvars`) を除外

### Terraform モジュール群 (`terraform/`)
| モジュール | 作成するリソース |
|---|---|
| `modules/vpc` | VPC・サブネット(パブリック×2, プライベート×2)・IGW・ルートテーブル |
| `modules/security_groups` | ALB用SG・EC2用SG・RDS用SG |
| `modules/secrets` | Secrets Manager (DB認証情報・JWT鍵) |
| `modules/rds` | RDS PostgreSQL 16 (db.t3.micro, プライベートサブネット) |
| `modules/ec2` | EC2 t3.micro + IAM Role + user_data.sh (Java21インストール・systemd設定) |
| `modules/alb` | ALB + TargetGroup + Listener (HTTP:80) |
| `modules/frontend` | S3 + CloudFront (OAC, SPA対応カスタムエラー) |

### ドキュメント
- `docs/aws-deploy.md`: Phase 0〜4 の完全手順書（AWS/Terraform 概念解説・用語早見表・トラブルシューティング含む）

## テスト計画

- [x] `npm run lint` — エラー 0 件
- [x] `npx tsc --noEmit` — エラー 0 件
- [x] `./gradlew checkstyleMain` — BUILD SUCCESSFUL
- [x] `./gradlew build -x test` — BUILD SUCCESSFUL
- [ ] `terraform init && terraform plan` — 実際の AWS 環境で確認（実行前に `terraform.tfvars` の設定が必要）

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)