### PR TITLE
chore(infra): Terraform構成をEC2単体の最小構成に変更する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 backend_tmp/
 backend_tmp.zip
+
+# Terraform
+terraform/terraform.tfvars
+terraform/terraform.tfstate
+terraform/terraform.tfstate.backup
+terraform/.terraform/

--- a/docs/aws-deploy.md
+++ b/docs/aws-deploy.md
@@ -1,0 +1,340 @@
+# AWS デプロイ手順書（Step 1: EC2 単体構成）
+
+AWS + Terraform を使って TaskManagement を EC2 にデプロイする手順です。
+段階的に進めるため、まずは EC2 1台でバックエンド・フロントエンド両方を動かします。
+
+---
+
+## アーキテクチャ
+
+```
+あなたのPC（my_ip_cidr で制限）
+  │
+  │ HTTP:80（Nginx）/ SSH:22
+  ▼
+EC2 t2.micro（パブリックIP）
+  ├── Nginx :80
+  │     ├── /         → React 静的ファイル（/var/www/taskmanagement）
+  │     ├── /api/*    → localhost:8080 にプロキシ
+  │     └── /actuator/* → localhost:8080 にプロキシ
+  └── Spring Boot :8080（EC2 内部のみ、外部非公開）
+```
+
+**セキュリティ方針**: SSH・HTTP ともに `my_ip_cidr`（自分のPCのIP）からのみ許可。
+Spring Boot の 8080 ポートは外部に公開せず、Nginx 経由でのみアクセス可能。
+
+---
+
+## 使用する AWS サービスと無料枠
+
+| サービス | スペック | 無料枠 |
+|---|---|---|
+| EC2 | t2.micro | 12ヶ月・月750時間無料 |
+| VPC / セキュリティグループ / IGW | — | 永続無料 |
+
+---
+
+## Phase 0: 事前準備
+
+### 0-1. AWS CLI のインストールと設定
+
+```bash
+# macOS
+brew install awscli
+
+# 設定（アクセスキーは AWS コンソール > IAM > セキュリティ認証情報で発行）
+aws configure
+# AWS Access Key ID: <アクセスキーID>
+# AWS Secret Access Key: <シークレットアクセスキー>
+# Default region name: ap-northeast-1
+# Default output format: json
+```
+
+### 0-2. Terraform のインストール
+
+```bash
+brew tap hashicorp/tap
+brew install hashicorp/tap/terraform
+
+# バージョン確認
+terraform version  # >= 1.9.0 であること
+```
+
+### 0-3. SSH キーペアの作成・AWS への登録
+
+```bash
+# ローカルで SSH キーを生成
+ssh-keygen -t ed25519 -f ~/.ssh/taskmanagement-key -N ""
+
+# AWS に公開鍵を登録
+aws ec2 import-key-pair \
+  --key-name "taskmanagement-key" \
+  --public-key-material fileb://~/.ssh/taskmanagement-key.pub \
+  --region ap-northeast-1
+
+# 登録確認
+aws ec2 describe-key-pairs --key-names taskmanagement-key --region ap-northeast-1
+```
+
+---
+
+## Phase 1: Terraform でインフラ構築
+
+### 1-1. terraform.tfvars の設定
+
+```bash
+cd terraform
+cp terraform.tfvars.example terraform.tfvars
+```
+
+[terraform/terraform.tfvars](../terraform/terraform.tfvars) を編集：
+
+```hcl
+aws_region        = "ap-northeast-1"
+project_name      = "taskmanagement"
+ec2_key_pair_name = "taskmanagement-key"
+
+# 自分のグローバル IP を確認してから設定
+# curl ifconfig.me
+my_ip_cidr = "xxx.xxx.xxx.xxx/32"
+```
+
+### 1-2. Terraform の初期化と適用
+
+```bash
+cd terraform
+
+# プロバイダーのダウンロード（初回のみ）
+terraform init
+
+# 作成されるリソースの確認（実際には何も変更しない）
+terraform plan
+
+# インフラ構築（yes と入力して確定）
+terraform apply
+```
+
+完了すると以下が出力されます：
+
+```
+Outputs:
+  ec2_public_ip    = "xxx.xxx.xxx.xxx"
+  app_url          = "http://xxx.xxx.xxx.xxx"
+  api_health_url   = "http://xxx.xxx.xxx.xxx/actuator/health"
+```
+
+### 1-3. EC2 の起動完了を確認
+
+EC2 起動直後は User Data（初期セットアップスクリプト）が実行中です。
+SSH で接続してログを確認します：
+
+```bash
+EC2_IP=$(cd terraform && terraform output -raw ec2_public_ip)
+
+# SSH 接続（User Data 完了まで 2〜3 分かかる場合があります）
+ssh -i ~/.ssh/taskmanagement-key ec2-user@$EC2_IP
+
+# EC2 内でセットアップログを確認
+sudo cat /var/log/user-data-setup.log
+# 末尾に "=== user_data setup complete ===" が出ていれば成功
+```
+
+### 1-4. Nginx の動作確認
+
+```bash
+# Nginx が起動していることを確認
+curl http://$EC2_IP/
+# "TaskManagement サーバー起動中" というページが返ってくればOK
+
+# SSH 内でサービス状態確認
+sudo systemctl status nginx
+```
+
+---
+
+## Phase 2: バックエンド（Spring Boot）のデプロイ
+
+### 2-1. JAR ファイルをビルド
+
+```bash
+cd backend
+./gradlew bootJar -x test
+
+# ビルド結果を確認
+ls build/libs/*.jar
+```
+
+### 2-2. EC2 に JAR を転送
+
+```bash
+EC2_IP=$(cd terraform && terraform output -raw ec2_public_ip)
+
+scp -i ~/.ssh/taskmanagement-key \
+  backend/build/libs/taskmanagement-*.jar \
+  ec2-user@$EC2_IP:/opt/taskmanagement/app.jar
+```
+
+### 2-3. 環境変数ファイル（.env）を作成
+
+Spring Boot はこのファイルから設定を読み込みます。
+EC2 に SSH した上で作成してください：
+
+```bash
+ssh -i ~/.ssh/taskmanagement-key ec2-user@$EC2_IP
+
+# EC2 内で実行
+cat > /opt/taskmanagement/.env << 'EOF'
+# データベース設定（Step 1 では EC2 内 H2 などを使う場合はURLを調整）
+DB_URL=jdbc:postgresql://localhost:5432/taskmanagement
+DB_USERNAME=taskuser
+DB_PASSWORD=<強力なパスワード>
+
+# JWT 署名鍵（openssl rand -hex 32 で生成）
+JWT_SECRET=<256ビット以上のランダム文字列>
+
+# Spring Boot 設定
+JPA_DDL_AUTO=update
+CORS_ALLOWED_ORIGIN=http://<EC2_IP>
+EOF
+
+chmod 600 /opt/taskmanagement/.env
+```
+
+### 2-4. Spring Boot を起動
+
+```bash
+# EC2 内で実行
+sudo systemctl start taskmanagement
+sudo systemctl status taskmanagement
+```
+
+### 2-5. バックエンドの動作確認
+
+```bash
+# Nginx 経由でアクセス（推奨）
+curl http://$EC2_IP/actuator/health
+# {"status":"UP"} が返れば成功
+```
+
+---
+
+## Phase 3: フロントエンドのデプロイ
+
+### 3-1. React をビルド
+
+フロントエンドとバックエンドは同じ EC2・同じ Origin（`http://<EC2_IP>`）で動くため、
+`VITE_API_BASE_URL` の設定は不要です。Nginx が `/api/*` を Spring Boot にプロキシします。
+
+```bash
+cd frontend
+npm install
+npm run build
+# dist/ にビルド済みファイルが生成される
+```
+
+### 3-2. ビルドファイルを EC2 に転送
+
+```bash
+EC2_IP=$(cd terraform && terraform output -raw ec2_public_ip)
+
+scp -i ~/.ssh/taskmanagement-key \
+  -r frontend/dist/* \
+  ec2-user@$EC2_IP:/var/www/taskmanagement/
+```
+
+### 3-3. 動作確認
+
+ブラウザで `http://<EC2_IP>` にアクセスしてアプリが表示されることを確認します。
+
+---
+
+## 更新デプロイ手順
+
+### バックエンドを更新する場合
+
+```bash
+EC2_IP=$(cd terraform && terraform output -raw ec2_public_ip)
+
+# JAR を再ビルド・転送
+cd backend && ./gradlew bootJar -x test
+scp -i ~/.ssh/taskmanagement-key \
+  build/libs/taskmanagement-*.jar \
+  ec2-user@$EC2_IP:/opt/taskmanagement/app.jar
+
+# サービスを再起動
+ssh -i ~/.ssh/taskmanagement-key ec2-user@$EC2_IP \
+  "sudo systemctl restart taskmanagement"
+```
+
+### フロントエンドを更新する場合
+
+```bash
+EC2_IP=$(cd terraform && terraform output -raw ec2_public_ip)
+
+cd frontend && npm run build
+scp -i ~/.ssh/taskmanagement-key \
+  -r dist/* \
+  ec2-user@$EC2_IP:/var/www/taskmanagement/
+# Nginx の再起動は不要（静的ファイルを置き換えるだけで即反映）
+```
+
+---
+
+## 注意事項
+
+### EC2 の IP アドレスについて
+
+EC2 を**停止→起動**するとパブリック IP が変わります。
+
+```bash
+# 再起動後の IP を確認
+cd terraform && terraform output ec2_public_ip
+```
+
+IP が変わったら `.env` の `CORS_ALLOWED_ORIGIN` と、
+フロントを別ホストで動かす場合は `VITE_API_BASE_URL` も更新してください。
+
+### EC2 の停止・削除
+
+```bash
+# EC2 を一時停止（課金が止まる。IP は変わる）
+aws ec2 stop-instances --instance-ids <インスタンスID>
+
+# インフラをすべて削除（学習終了時）
+cd terraform && terraform destroy
+```
+
+---
+
+## トラブルシューティング
+
+### User Data のログを確認する
+
+```bash
+ssh -i ~/.ssh/taskmanagement-key ec2-user@$EC2_IP
+sudo cat /var/log/user-data-setup.log
+```
+
+### Spring Boot のログを確認する
+
+```bash
+ssh -i ~/.ssh/taskmanagement-key ec2-user@$EC2_IP
+journalctl -u taskmanagement -f        # リアルタイムで見る
+journalctl -u taskmanagement --no-pager -n 50  # 直近50行
+```
+
+### Nginx のログを確認する
+
+```bash
+ssh -i ~/.ssh/taskmanagement-key ec2-user@$EC2_IP
+sudo journalctl -u nginx -f
+sudo cat /var/log/nginx/error.log
+```
+
+### Nginx の設定を再読み込みする
+
+```bash
+ssh -i ~/.ssh/taskmanagement-key ec2-user@$EC2_IP
+sudo nginx -t                        # 設定ファイルの構文チェック
+sudo systemctl reload nginx          # 設定を再読み込み（サービスは止めない）
+```

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,32 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      Environment = var.environment
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+module "vpc" {
+  source       = "./modules/vpc"
+  project_name = var.project_name
+}
+
+module "security_groups" {
+  source       = "./modules/security_groups"
+  project_name = var.project_name
+  vpc_id       = module.vpc.vpc_id
+  my_ip_cidr   = var.my_ip_cidr
+}
+
+module "ec2" {
+  source             = "./modules/ec2"
+  project_name       = var.project_name
+  subnet_id          = module.vpc.public_subnet_id
+  security_group_ids = [module.security_groups.ec2_sg_id]
+  key_pair_name      = var.ec2_key_pair_name
+  aws_region         = var.aws_region
+}

--- a/terraform/modules/ec2/main.tf
+++ b/terraform/modules/ec2/main.tf
@@ -1,0 +1,36 @@
+# Amazon Linux 2023 の最新 AMI を動的に取得
+# AMI ID はリージョンやアップデートで変わるため、ハードコードせず data source で取得する
+data "aws_ami" "amazon_linux_2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# EC2 インスタンス（t2.micro: AWS 無料枠対象）
+resource "aws_instance" "main" {
+  ami                    = data.aws_ami.amazon_linux_2023.id
+  instance_type          = "t2.micro"
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = var.security_group_ids
+  key_name               = var.key_pair_name
+
+  # user_data：EC2 起動時に一度だけ実行されるシェルスクリプト
+  # Java・Nginx のインストールと systemd サービスの設定を行う
+  user_data = templatefile("${path.module}/user_data.sh", {
+    project_name = var.project_name
+    aws_region   = var.aws_region
+  })
+
+  tags = {
+    Name = "${var.project_name}-server"
+  }
+}

--- a/terraform/modules/ec2/outputs.tf
+++ b/terraform/modules/ec2/outputs.tf
@@ -1,0 +1,9 @@
+output "instance_id" {
+  description = "EC2 インスタンス ID"
+  value       = aws_instance.main.id
+}
+
+output "public_ip" {
+  description = "EC2 パブリック IP アドレス"
+  value       = aws_instance.main.public_ip
+}

--- a/terraform/modules/ec2/user_data.sh
+++ b/terraform/modules/ec2/user_data.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -euo pipefail
+
+LOG=/var/log/user-data-setup.log
+exec > >(tee -a $LOG) 2>&1
+
+echo "=== [1/3] Java 21 インストール ==="
+dnf install -y java-21-amazon-corretto
+
+echo "=== [2/3] Nginx インストール・設定 ==="
+dnf install -y nginx
+
+# Nginx の設定：フロントエンド静的配信 + Spring Boot へのリバースプロキシ
+cat > /etc/nginx/conf.d/taskmanagement.conf << 'NGINXEOF'
+server {
+    listen 80;
+    server_name _;
+
+    # React SPA の静的ファイルを配信
+    root /var/www/taskmanagement;
+    index index.html;
+
+    # React SPA：未知のパスはすべて index.html にフォールバック
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Spring Boot API へのリバースプロキシ
+    # EC2 内部の通信（localhost:8080）なので外部に 8080 を公開しなくてよい
+    location /api/ {
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # Spring Boot Actuator（ヘルスチェック）
+    location /actuator/ {
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+NGINXEOF
+
+# フロントエンド配信ディレクトリを作成（デプロイ前の仮ページ）
+mkdir -p /var/www/taskmanagement
+cat > /var/www/taskmanagement/index.html << 'HTMLEOF'
+<!DOCTYPE html>
+<html lang="ja">
+<head><meta charset="UTF-8"><title>TaskManagement</title></head>
+<body>
+<h1>TaskManagement サーバー起動中</h1>
+<p>フロントエンドのビルドファイルをデプロイしてください。</p>
+<p><a href="/actuator/health">バックエンド ヘルスチェック</a></p>
+</body>
+</html>
+HTMLEOF
+
+chown -R nginx:nginx /var/www/taskmanagement
+systemctl enable nginx
+systemctl start nginx
+
+echo "=== [3/3] Spring Boot サービス設定 ==="
+mkdir -p /opt/taskmanagement
+chown ec2-user:ec2-user /opt/taskmanagement
+
+# systemd サービスファイルを作成
+# .env ファイルから環境変数を読み込んで Spring Boot を起動する
+cat > /etc/systemd/system/taskmanagement.service << 'SVCEOF'
+[Unit]
+Description=TaskManagement Backend (Spring Boot)
+After=network.target
+
+[Service]
+Type=simple
+User=ec2-user
+WorkingDirectory=/opt/taskmanagement
+EnvironmentFile=/opt/taskmanagement/.env
+ExecStart=/usr/bin/java -jar /opt/taskmanagement/app.jar
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+SVCEOF
+
+systemctl daemon-reload
+systemctl enable taskmanagement
+# JAR がまだないため起動しない。JAR デプロイ後に手動で start する
+
+echo "=== user_data setup complete ==="

--- a/terraform/modules/ec2/user_data.sh
+++ b/terraform/modules/ec2/user_data.sh
@@ -13,8 +13,8 @@ dnf install -y nginx
 # Nginx の設定：フロントエンド静的配信 + Spring Boot へのリバースプロキシ
 cat > /etc/nginx/conf.d/taskmanagement.conf << 'NGINXEOF'
 server {
-    listen 80;
-    server_name _;
+    listen 80 default_server;
+    server_name "";
 
     # React SPA の静的ファイルを配信
     root /var/www/taskmanagement;

--- a/terraform/modules/ec2/variables.tf
+++ b/terraform/modules/ec2/variables.tf
@@ -1,0 +1,21 @@
+variable "project_name" {
+  type = string
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "EC2 を配置するパブリックサブネット ID"
+}
+
+variable "security_group_ids" {
+  type = list(string)
+}
+
+variable "key_pair_name" {
+  type        = string
+  description = "EC2 SSH 接続に使うキーペア名"
+}
+
+variable "aws_region" {
+  type = string
+}

--- a/terraform/modules/security_groups/main.tf
+++ b/terraform/modules/security_groups/main.tf
@@ -1,0 +1,40 @@
+# セキュリティグループ（Security Group）
+# EC2 への通信を許可・拒否するファイアウォールルール。
+# 「どこから・どのポートへの通信を許すか」を定義する。
+
+# EC2 用 SG：自分の PC からの HTTP（80）と SSH（22）のみ許可
+# ポート 8080（Spring Boot）は EC2 内の Nginx がローカルでプロキシするため、
+# 外部に公開しない。
+resource "aws_security_group" "ec2" {
+  name        = "${var.project_name}-ec2-sg"
+  description = "EC2: allow HTTP(80) and SSH(22) from my IP only"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.my_ip_cidr]
+    description = "SSH from my IP only"
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [var.my_ip_cidr]
+    description = "HTTP (Nginx) from my IP only"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound (for package install etc.)"
+  }
+
+  tags = {
+    Name = "${var.project_name}-ec2-sg"
+  }
+}

--- a/terraform/modules/security_groups/outputs.tf
+++ b/terraform/modules/security_groups/outputs.tf
@@ -1,0 +1,4 @@
+output "ec2_sg_id" {
+  description = "EC2 セキュリティグループ ID"
+  value       = aws_security_group.ec2.id
+}

--- a/terraform/modules/security_groups/variables.tf
+++ b/terraform/modules/security_groups/variables.tf
@@ -1,0 +1,13 @@
+variable "project_name" {
+  type = string
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "セキュリティグループを作成する VPC の ID"
+}
+
+variable "my_ip_cidr" {
+  type        = string
+  description = "SSH・HTTP を許可する自分の IP（例: 1.2.3.4/32）"
+}

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -1,0 +1,54 @@
+# VPC
+# AWS 内の独立したネットワーク空間。外部からの不正アクセスを防ぎ、
+# リソース間の通信を制御するための基盤となる。
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.project_name}-vpc"
+  }
+}
+
+# パブリックサブネット（EC2 を配置）
+# インターネットゲートウェイ経由でインターネットに接続できる
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.project_name}-public-a"
+  }
+}
+
+# インターネットゲートウェイ（VPC からインターネットへの出口）
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project_name}-igw"
+  }
+}
+
+# パブリックサブネット用ルートテーブル（IGW 経由でインターネットへ）
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public_a" {
+  subnet_id      = aws_subnet.public_a.id
+  route_table_id = aws_route_table.public.id
+}

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,8 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnet_id" {
+  description = "EC2 を配置するパブリックサブネット ID"
+  value       = aws_subnet.public_a.id
+}

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,0 +1,3 @@
+variable "project_name" {
+  type = string
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "ec2_public_ip" {
+  description = "EC2 のパブリック IP（SSH 接続・アクセス先）"
+  value       = module.ec2.public_ip
+}
+
+output "app_url" {
+  description = "アプリ URL（Nginx 経由、ブラウザでアクセス）"
+  value       = "http://${module.ec2.public_ip}"
+}
+
+output "api_health_url" {
+  description = "Spring Boot ヘルスチェック URL（動作確認用）"
+  value       = "http://${module.ec2.public_ip}/actuator/health"
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,10 @@
+# このファイルを terraform.tfvars にコピーして実際の値を入力してください
+# terraform.tfvars は .gitignore で Git 管理対象外になっています
+
+aws_region        = "ap-northeast-1"
+project_name      = "taskmanagement"
+ec2_key_pair_name = "taskmanagement-key"
+
+# 自分のグローバル IP を確認: curl ifconfig.me
+# EC2 への SSH と HTTP アクセスをこの IP からのみ許可する
+my_ip_cidr = "YOUR_GLOBAL_IP/32"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,27 @@
+variable "aws_region" {
+  description = "AWSリージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "project_name" {
+  description = "プロジェクト名（リソース命名に使用）"
+  type        = string
+  default     = "taskmanagement"
+}
+
+variable "environment" {
+  description = "環境名"
+  type        = string
+  default     = "learning"
+}
+
+variable "ec2_key_pair_name" {
+  description = "EC2 SSH 接続に使うキーペア名（aws ec2 import-key-pair で登録済みのもの）"
+  type        = string
+}
+
+variable "my_ip_cidr" {
+  description = "SSH・HTTP を許可する自分の IP（例: 1.2.3.4/32）。curl ifconfig.me で確認できる"
+  type        = string
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## 概要
- ALB・RDS・S3+CloudFront・Secrets Manager を削除し、EC2 1台のシンプル構成に変更
- フロントエンドとバックエンドを同一 EC2（Nginx + Spring Boot）で動かす
- セキュリティグループは自分の IP からのみ許可（SSH・HTTP）

## 変更内容
- `modules/alb/`, `modules/rds/`, `modules/frontend/`, `modules/secrets/` を削除
- EC2 インスタンスタイプ: t3.micro → t2.micro（無料枠確実）
- VPC サブネット: 4つ → 1つ（パブリックのみ）
- SG: EC2 用のみ。ポート 22・80 を `my_ip_cidr` からのみ許可
- User Data に Nginx インストール・設定を追加（/api/* を Spring Boot にプロキシ）
- IAM ロール削除（Secrets Manager 不使用、.env ファイルで管理）
- `docs/aws-deploy.md` を Step 1（EC2単体）向けに全面改訂

## 今後のステップ
- Step 2: RDS（PostgreSQL）を追加
- Step 3: フロントエンド配信の検討

## テスト計画
- [ ] `terraform validate` で構成エラーがないことを確認（済）
- [ ] `terraform plan` でリソース内容を確認
- [ ] `terraform apply` で EC2 が起動することを確認
- [ ] SSH 接続 → `/var/log/user-data-setup.log` で "setup complete" を確認
- [ ] `curl http://<EC2_IP>/` で Nginx の仮ページが返ることを確認

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)